### PR TITLE
Relax crypto requirements for the http file client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.cognite</groupId>
     <artifactId>cdf-sdk-java</artifactId>
-    <version>0.9.8</version>
+    <version>0.9.9-SNAPSHOT</version>
     <licenses>
         <license>
             <name>Apache 2</name>
@@ -44,7 +44,7 @@
         <auto.version>1.8.1</auto.version>
 
         <nimbusds.version>9.4</nimbusds.version>
-        <jgrapht.version>1.5.1</jgrapht.version> <!-- Upgrade to 1.5.0++ when Java 11 is available -->
+        <jgrapht.version>1.5.1</jgrapht.version>
         <okhttp3.version>4.9.1</okhttp3.version>
         <jackson.version>2.12.3</jackson.version>
         <slf4j.version>1.7.30</slf4j.version>

--- a/src/main/java/com/cognite/client/servicesV1/ConnectorServiceV1.java
+++ b/src/main/java/com/cognite/client/servicesV1/ConnectorServiceV1.java
@@ -2749,7 +2749,7 @@ public abstract class ConnectorServiceV1 implements Serializable {
         final static OkHttpClient client = new OkHttpClient.Builder()
                 .connectionSpecs(Arrays.asList(ConnectionSpec.MODERN_TLS, ConnectionSpec.COMPATIBLE_TLS))
                 .connectTimeout(90, TimeUnit.SECONDS)
-                .readTimeout(180, TimeUnit.MINUTES)
+                .readTimeout(90, TimeUnit.SECONDS)
                 .build();
 
         public static CompletableFuture<FileBinary> downloadFileBinaryFromURL(String downloadUrl) {

--- a/src/main/java/com/cognite/client/servicesV1/ConnectorServiceV1.java
+++ b/src/main/java/com/cognite/client/servicesV1/ConnectorServiceV1.java
@@ -42,6 +42,7 @@ import com.cognite.v1.timeseries.proto.DataPointListItem;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
+import okhttp3.ConnectionSpec;
 import okhttp3.HttpUrl;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.slf4j.Logger;
@@ -2746,8 +2747,9 @@ public abstract class ConnectorServiceV1 implements Serializable {
         final static Logger LOG = LoggerFactory.getLogger(DownloadFileBinary.class);
         final static String loggingPrefix = "DownloadFileBinary() - ";
         final static OkHttpClient client = new OkHttpClient.Builder()
+                .connectionSpecs(Arrays.asList(ConnectionSpec.MODERN_TLS, ConnectionSpec.COMPATIBLE_TLS))
                 .connectTimeout(90, TimeUnit.SECONDS)
-                .readTimeout(30, TimeUnit.MINUTES)
+                .readTimeout(180, TimeUnit.MINUTES)
                 .build();
 
         public static CompletableFuture<FileBinary> downloadFileBinaryFromURL(String downloadUrl) {


### PR DESCRIPTION
Relax the crypto requirements for the file binary http client. In order to reduce SSL handshake errors.