### PR TITLE
Feature/enable cdf over http flag

### DIFF
--- a/docs/wiremockTesting.md
+++ b/docs/wiremockTesting.md
@@ -1,0 +1,99 @@
+# Unit testing with wiremock quick howto
+Enabling running wiremock using plain http, the environment variable "enableCdfOverHttp" 
+must be set to true. This can be done for example by using junit-pioneer @SetEnviromentVariable
+annotation.<br>
+**Note:** Currently only works with port 80!
+
+## Example
+
+### POM
+```
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.example</groupId>
+    <artifactId>MyTest</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.cognite</groupId>
+            <artifactId>cdf-sdk-java</artifactId>
+            <version>1.3.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.7.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit-pioneer</groupId>
+            <artifactId>junit-pioneer</artifactId>
+            <version>1.4.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-jre8</artifactId>
+            <version>2.31.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>
+```
+
+### Junit java class
+```java
+import com.cognite.client.CogniteClient;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.SetEnvironmentVariable;
+
+import java.util.Iterator;
+import java.util.List;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+
+@WireMockTest(httpPort = 80)
+public class TestCdfMock {
+
+    @Test
+    @SetEnvironmentVariable(key = "enableCdfOverHttp", value = "true")
+    public void testCdfConnect(WireMockRuntimeInfo wireMockRuntimeInfo) throws Exception {
+        stubFor(get("/login/status").willReturn(ok().withBody("{\n" +
+                "    \"data\": {\n" +
+                "        \"user\": \"some.user@cognite.com\",\n" +
+                "        \"loggedIn\": true,\n" +
+                "        \"project\": \"dev\",\n" +
+                "        \"projectId\": 123456789,\n" +
+                "        \"apiKeyId\": 987654321\n" +
+                "    }\n" +
+                "}")));
+
+        stubFor(get(urlPathEqualTo("/api/v1/projects/dev/raw/dbs")).willReturn(ok().withBody("{\n" +
+                "    \"items\": [\n" +
+                "        {\n" +
+                "            \"name\": \"MY_DB\"\n" +
+                "        }\n" +
+                "    ],\n" +
+                "    \"nextCursor\": \"wIxxsu58VLnXfHvBQL8v3g==\"\n" +
+                "}")));
+
+        CogniteClient client = CogniteClient.ofKey("TEST").withBaseUrl("http://localhost/");
+        Iterator<List<String>> databases = client.raw().databases().list();
+        System.out.println(databases.next());
+        System.out.println(databases);
+    }
+}
+```

--- a/docs/wiremockTesting.md
+++ b/docs/wiremockTesting.md
@@ -36,12 +36,6 @@ annotation.<br>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.junit-pioneer</groupId>
-            <artifactId>junit-pioneer</artifactId>
-            <version>1.4.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock-jre8</artifactId>
             <version>2.31.0</version>
@@ -58,18 +52,16 @@ import com.cognite.client.CogniteClient;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import org.junit.jupiter.api.Test;
-import org.junitpioneer.jupiter.SetEnvironmentVariable;
-
 import java.util.Iterator;
 import java.util.List;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 @WireMockTest(httpPort = 80)
 public class TestCdfMock {
 
     @Test
-    @SetEnvironmentVariable(key = "enableCdfOverHttp", value = "true")
     public void testCdfConnect(WireMockRuntimeInfo wireMockRuntimeInfo) throws Exception {
         stubFor(get("/login/status").willReturn(ok().withBody("{\n" +
                 "    \"data\": {\n" +
@@ -90,10 +82,10 @@ public class TestCdfMock {
                 "    \"nextCursor\": \"wIxxsu58VLnXfHvBQL8v3g==\"\n" +
                 "}")));
 
-        CogniteClient client = CogniteClient.ofKey("TEST").withBaseUrl("http://localhost/");
+        CogniteClient client = CogniteClient.ofKey("TEST").withBaseUrl("http://localhost/").enableHttp(true);
         Iterator<List<String>> databases = client.raw().databases().list();
-        System.out.println(databases.next());
-        System.out.println(databases);
+        assertTrue(databases.hasNext());
+        assertEquals(1, databases.next().size());
     }
 }
 ```

--- a/docs/wiremockTesting.md
+++ b/docs/wiremockTesting.md
@@ -30,12 +30,6 @@ annotation.<br>
             <version>1.3.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>5.7.2</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock-jre8</artifactId>
             <version>2.31.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -162,6 +162,12 @@
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit-pioneer</groupId>
+            <artifactId>junit-pioneer</artifactId>
+            <version>1.4.2</version>
+            <scope>test</scope>
+        </dependency>
    </dependencies>
 
    <build>

--- a/pom.xml
+++ b/pom.xml
@@ -162,12 +162,6 @@
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.junit-pioneer</groupId>
-            <artifactId>junit-pioneer</artifactId>
-            <version>1.4.2</version>
-            <scope>test</scope>
-        </dependency>
    </dependencies>
 
    <build>

--- a/src/main/java/com/cognite/client/CogniteClient.java
+++ b/src/main/java/com/cognite/client/CogniteClient.java
@@ -27,7 +27,6 @@ import java.net.URI;
 import java.net.URL;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.*;
 import java.util.function.Supplier;
@@ -77,8 +76,12 @@ public abstract class CogniteClient implements Serializable {
     to add specific interceptor depending on the auth method used.
      */
     private static OkHttpClient.Builder getHttpClientBuilder() {
+        return getHttpClientBuilder(false);
+    }
+
+    private static OkHttpClient.Builder getHttpClientBuilder(boolean enableHttp) {
         List<ConnectionSpec> connectionSpecs = Lists.newArrayList(ConnectionSpec.MODERN_TLS, ConnectionSpec.COMPATIBLE_TLS);
-        if (Boolean.parseBoolean(System.getenv("enableCdfOverHttp"))) {
+        if (enableHttp) {
             connectionSpecs.add(ConnectionSpec.CLEARTEXT);
         }
         return new OkHttpClient.Builder()
@@ -210,6 +213,7 @@ public abstract class CogniteClient implements Serializable {
     public abstract ClientConfig getClientConfig();
     public abstract OkHttpClient getHttpClient();
 
+
     public ExecutorService getExecutorService() {
         return executorService;
     }
@@ -223,6 +227,24 @@ public abstract class CogniteClient implements Serializable {
     public CogniteClient withProject(String project) {
         return toBuilder().setProject(project).build();
     }
+
+    /**
+     * Returns a {@link CogniteClient} enabling basic HTTP requests.
+     * This should not be used in production environment, but is enabled for testing.
+     *
+     * @return the client object with the base URL set.
+     */
+    public CogniteClient withHttp() {
+        List<Interceptor> interceptorList = toBuilder().build().getHttpClient().interceptors();
+        OkHttpClient.Builder httpClientBuilder = CogniteClient.getHttpClientBuilder(true);
+        for(Interceptor interceptor: interceptorList){
+            httpClientBuilder.addInterceptor(interceptor);
+        }
+        return toBuilder()
+                .setHttpClient(httpClientBuilder.build())
+                .build();
+    }
+
 
     /**
      * Returns a {@link CogniteClient} using the specified base URL for issuing API requests.

--- a/src/main/java/com/cognite/client/CogniteClient.java
+++ b/src/main/java/com/cognite/client/CogniteClient.java
@@ -6,6 +6,7 @@ import com.cognite.client.config.ClientConfig;
 import com.cognite.client.servicesV1.ConnectorServiceV1;
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
 import com.nimbusds.oauth2.sdk.auth.ClientAuthentication;
 import com.nimbusds.oauth2.sdk.auth.ClientSecretBasic;
 import com.nimbusds.oauth2.sdk.auth.Secret;
@@ -27,6 +28,7 @@ import java.net.URL;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.*;
 import java.util.function.Supplier;
 
@@ -75,8 +77,12 @@ public abstract class CogniteClient implements Serializable {
     to add specific interceptor depending on the auth method used.
      */
     private static OkHttpClient.Builder getHttpClientBuilder() {
+        List<ConnectionSpec> connectionSpecs = Lists.newArrayList(ConnectionSpec.MODERN_TLS, ConnectionSpec.COMPATIBLE_TLS);
+        if (Boolean.parseBoolean(System.getenv("enableCdfOverHttp"))) {
+            connectionSpecs.add(ConnectionSpec.CLEARTEXT);
+        }
         return new OkHttpClient.Builder()
-                .connectionSpecs(Arrays.asList(ConnectionSpec.MODERN_TLS, ConnectionSpec.COMPATIBLE_TLS))
+                .connectionSpecs(connectionSpecs)
                 .connectTimeout(15, TimeUnit.SECONDS)
                 .readTimeout(15, TimeUnit.SECONDS)
                 .writeTimeout(15, TimeUnit.SECONDS);

--- a/src/test/java/com/cognite/client/CogniteClientTest.java
+++ b/src/test/java/com/cognite/client/CogniteClientTest.java
@@ -1,0 +1,54 @@
+package com.cognite.client;
+
+import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.SetEnvironmentVariable;
+
+import java.util.Iterator;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CogniteClientTest {
+
+    @Test
+    /** Expects java.net.UnknownServiceException: CLEARTEXT communication not enabled for client as basic HTTP is not supported */
+    void test_block_http_URI() throws Exception {
+        Exception exception = assertThrows(java.net.UnknownServiceException.class, () -> {
+            try {
+                CogniteClient client = CogniteClient.ofKey("TEST").withBaseUrl("http://localhost");
+                Iterator<List<String>> databases = client.raw().databases().list();
+            }catch (java.util.concurrent.CompletionException e) {
+                throw e.getCause();
+            }
+        });
+    }
+
+    @Test
+    /** Expects connection refused (no localhost exist) */
+    void test_accept_https_URI() throws Exception {
+        Exception exception = assertThrows(java.net.ConnectException.class, () -> {
+            try {
+                CogniteClient client = CogniteClient.ofKey("TEST").withBaseUrl("https://localhost");
+                Iterator<List<String>> databases = client.raw().databases().list();
+            }catch (java.util.concurrent.CompletionException e) {
+                throw e.getCause();
+            }
+        });
+    }
+
+    @Test
+    /** Expects connection refused (no localhost exist) */
+    @SetEnvironmentVariable(key = "enableCdfOverHttp", value = "true")
+    void test_accept_http_URI_withFlag() throws Exception {
+        //System.setProperty("enableCdfOverHttp", Boolean.TRUE.toString());
+        Exception exception = assertThrows(java.net.ConnectException.class, () -> {
+            try {
+                CogniteClient client = CogniteClient.ofKey("TEST").withBaseUrl("http://localhost");
+                Iterator<List<String>> databases = client.raw().databases().list();
+            }catch (java.util.concurrent.CompletionException e) {
+                throw e.getCause();
+            }
+        });
+        System.getProperties().remove("enableCdfOverHttp");
+    }
+}

--- a/src/test/java/com/cognite/client/CogniteClientTest.java
+++ b/src/test/java/com/cognite/client/CogniteClientTest.java
@@ -1,8 +1,11 @@
 package com.cognite.client;
 
+import okhttp3.ConnectionSpec;
+import okhttp3.Interceptor;
 import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.SetEnvironmentVariable;
 
+import java.net.URL;
 import java.util.Iterator;
 import java.util.List;
 
@@ -10,6 +13,42 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class CogniteClientTest {
 
+    @Test
+    void test_ofKey_config() throws Exception {
+        CogniteClient client = CogniteClient.ofKey("TEST").withBaseUrl("https://localhost");
+        assertNotNull(client.getHttpClient());
+        List<Interceptor> interceptorList = client.getHttpClient().interceptors();
+        assertNotNull(interceptorList);
+        assertEquals(1, interceptorList.size());
+        assertEquals("com.cognite.client.CogniteClient$ApiKeyInterceptor", interceptorList.get(0).getClass().getName());
+        assertEquals("TEST", client.getApiKey());
+        assertEquals("https://localhost", client.getBaseUrl());
+    }
+
+    @Test
+    void test_ofClientCredentials_config() throws Exception {
+        CogniteClient client = CogniteClient.ofClientCredentials("123", "secret", new URL("https://localhost/cogniteapi")).withBaseUrl("https://localhost");
+        assertNotNull(client.getHttpClient());
+        List<Interceptor> interceptorList = client.getHttpClient().interceptors();
+        assertNotNull(interceptorList);
+        assertEquals(1, interceptorList.size());
+        assertEquals("com.cognite.client.CogniteClient$ClientCredentialsInterceptor", interceptorList.get(0).getClass().getName());
+        assertEquals("https://localhost", client.getBaseUrl());
+    }
+
+
+    @Test
+    void test_withHttp_config() throws Exception {
+        CogniteClient client = CogniteClient.ofKey("TEST").withBaseUrl("https://localhost").withHttp();
+        assertNotNull(client.getHttpClient());
+        List<Interceptor> interceptorList = client.getHttpClient().interceptors();
+        assertNotNull(interceptorList);
+        assertEquals(1, interceptorList.size());
+        assertEquals("com.cognite.client.CogniteClient$ApiKeyInterceptor", interceptorList.get(0).getClass().getName());
+        assertEquals("https://localhost", client.getBaseUrl());
+        List<ConnectionSpec> connectionSpecs = client.getHttpClient().connectionSpecs();
+        assertEquals(3, connectionSpecs.size());
+    }
     @Test
     /** Expects java.net.UnknownServiceException: CLEARTEXT communication not enabled for client as basic HTTP is not supported */
     void test_block_http_URI() throws Exception {
@@ -38,17 +77,14 @@ class CogniteClientTest {
 
     @Test
     /** Expects connection refused (no localhost exist) */
-    @SetEnvironmentVariable(key = "enableCdfOverHttp", value = "true")
     void test_accept_http_URI_withFlag() throws Exception {
-        //System.setProperty("enableCdfOverHttp", Boolean.TRUE.toString());
         Exception exception = assertThrows(java.net.ConnectException.class, () -> {
             try {
-                CogniteClient client = CogniteClient.ofKey("TEST").withBaseUrl("http://localhost");
+                CogniteClient client = CogniteClient.ofKey("TEST").withBaseUrl("http://localhost").withHttp();
                 Iterator<List<String>> databases = client.raw().databases().list();
             }catch (java.util.concurrent.CompletionException e) {
                 throw e.getCause();
             }
         });
-        System.getProperties().remove("enableCdfOverHttp");
     }
 }

--- a/src/test/java/com/cognite/client/CogniteClientTest.java
+++ b/src/test/java/com/cognite/client/CogniteClientTest.java
@@ -2,12 +2,8 @@ package com.cognite.client;
 
 import okhttp3.ConnectionSpec;
 import okhttp3.Interceptor;
-import org.checkerframework.framework.qual.IgnoreInWholeProgramInference;
 import org.junit.jupiter.api.Test;
-import org.junitpioneer.jupiter.SetEnvironmentVariable;
-
 import java.net.URL;
-import java.util.Iterator;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -15,7 +11,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class CogniteClientTest {
 
     @Test
-    void test_ofKey_config() throws Exception {
+    void test_ofKey_config() {
         CogniteClient client = CogniteClient.ofKey("TEST").withBaseUrl("https://localhost");
         assertNotNull(client.getHttpClient());
         List<Interceptor> interceptorList = client.getHttpClient().interceptors();
@@ -39,7 +35,7 @@ class CogniteClientTest {
 
 
     @Test
-    void test_withHttp_config() throws Exception {
+    void test_withHttp_config() {
         CogniteClient client = CogniteClient.ofKey("TEST").withBaseUrl("https://localhost").enableHttp(true);
         assertNotNull(client.getHttpClient());
         List<Interceptor> interceptorList = client.getHttpClient().interceptors();
@@ -50,5 +46,5 @@ class CogniteClientTest {
         List<ConnectionSpec> connectionSpecs = client.getHttpClient().connectionSpecs();
         assertEquals(3, connectionSpecs.size());
     }
-    
+
 }


### PR DESCRIPTION
To ease use of wiremock for unit testing code against CDF, it is helpfull to be able to use plain HTTP instead of HTTPS due to issues with accepting privately signed certificates in wiremock.