### PR TITLE
Fix casting exception

### DIFF
--- a/src/main/java/com/cognite/client/servicesV1/ConnectorServiceV1.java
+++ b/src/main/java/com/cognite/client/servicesV1/ConnectorServiceV1.java
@@ -2533,7 +2533,7 @@ public abstract class ConnectorServiceV1 implements Serializable {
 
                 // build file id and url
                 String fileExternalId = (String) fileRequestItem.getOrDefault("externalId", "");
-                long fileId = (Long) fileRequestItem.getOrDefault("id", -1);
+                long fileId = ((Number) fileRequestItem.getOrDefault("id", -1L)).longValue();
                 String downloadUrl = (String) fileRequestItem.get("downloadUrl");
 
                 CompletableFuture<ResponseItems<FileBinary>> future = DownloadFileBinary

--- a/src/main/java/com/cognite/client/servicesV1/ConnectorServiceV1.java
+++ b/src/main/java/com/cognite/client/servicesV1/ConnectorServiceV1.java
@@ -40,6 +40,7 @@ import com.cognite.client.servicesV1.response.*;
 import com.cognite.client.servicesV1.util.JsonUtil;
 import com.cognite.v1.timeseries.proto.DataPointListItem;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 import okhttp3.ConnectionSpec;
@@ -2523,18 +2524,18 @@ public abstract class ConnectorServiceV1 implements Serializable {
             // Start download the file binaries on separate threads
             List<CompletableFuture<ResponseItems<FileBinary>>> futuresList = new ArrayList<>();
 
-            for (String fileItem : fileItems) {
-                LOG.debug(loggingPrefix + "Building download request for file item: {}", fileItem);
-                Map<String, Object> fileRequestItem = objectMapper.readValue(fileItem, new TypeReference<Map<String, Object>>(){});
-                Preconditions.checkState(fileRequestItem != null && fileRequestItem.containsKey("downloadUrl"),
+            for (String fileItemJson : fileItems) {
+                LOG.debug(loggingPrefix + "Building download request for file item: {}", fileItemJson);
+                JsonNode rootNode = objectMapper.readTree(fileItemJson);
+                Preconditions.checkState(rootNode.path("downloadUrl").isTextual(),
                         "File response does not contain a valid *downloadUrl* item.");
-                Preconditions.checkState(fileRequestItem.containsKey("externalId") || fileRequestItem.containsKey("id"),
+                Preconditions.checkState(rootNode.path("externalId").isTextual() || rootNode.path("id").isIntegralNumber(),
                         "File response does not contain a file id nor externalId.");
 
                 // build file id and url
-                String fileExternalId = (String) fileRequestItem.getOrDefault("externalId", "");
-                long fileId = ((Number) fileRequestItem.getOrDefault("id", -1L)).longValue();
-                String downloadUrl = (String) fileRequestItem.get("downloadUrl");
+                String fileExternalId = rootNode.path("externalId").asText("");
+                long fileId = rootNode.path("id").asLong(0L);
+                String downloadUrl = rootNode.path("downloadUrl").textValue();
 
                 CompletableFuture<ResponseItems<FileBinary>> future = DownloadFileBinary
                         .downloadFileBinaryFromURL(downloadUrl,


### PR DESCRIPTION
Fix the runtime exception
```
2021-11-18 01:07:23.831 CETError message from worker: java.lang.Exception: Batch: mBE9a3 - Error when reading from Cognite Data Fusion. com.cognite.beam.io.fn.read.RetrieveItemsBaseFn.processElement(RetrieveItemsBaseFn.java:93) Caused by: java.lang.ClassCastException: class java.lang.Integer cannot be cast to class java.lang.Long (java.lang.Integer and java.lang.Long are in module java.base of loader 'bootstrap') 
com.cognite.client.servicesV1.ConnectorServiceV1$FileBinaryReader.readFileBinariesAsync(ConnectorServiceV1.java:2536)
com.cognite.client.servicesV1.ConnectorServiceV1$FileBinaryReader.readFileBinaries(ConnectorServiceV1.java:2479)
com.cognite.client.Files.splitAndDownloadFileBinaries(Files.java:957)
com.cognite.client.Files.downloadFileBinaries(Files.java:748)
```