### PR TITLE
Add batch-level retries on stream reset.

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -19,6 +19,12 @@ Changes are grouped as follows:
 
 - Geo-location attribute and resource type.
 
+## [1.7.0-SNAPSHOT]
+
+### Added
+
+- Improved robustness for file binary upload. Add batch-level retries when the http2 stream is reset. 
+
 ## [1.6.1] 2021-11-18
 
 ### Fixed

--- a/src/main/java/com/cognite/client/servicesV1/executor/FileBinaryRequestExecutor.java
+++ b/src/main/java/com/cognite/client/servicesV1/executor/FileBinaryRequestExecutor.java
@@ -87,7 +87,7 @@ public abstract class FileBinaryRequestExecutor {
             StreamResetException.class,
             SSLException.class,
             SSLProtocolException.class,
-            com.google.cloud.storage.StorageException.class     // Timeout when using GCS as temp storage
+            com.google.cloud.storage.StorageException.class     // Timeout + stream reset when using GCS as temp storage
     );
 
     private static final int DEFAULT_NUM_WORKERS = 8;
@@ -346,7 +346,7 @@ public abstract class FileBinaryRequestExecutor {
         }
 
         // No results are produced. Throw the list of registered Exception.
-        String exceptionMessage = String.format("Unable to download file binary from %s.",
+        String exceptionMessage = String.format(loggingPrefix + "Unable to download file binary from %s.",
                 request.url().toString());
         if (catchedExceptions.size() > 0) { //add the details of the most recent exception.
             exceptionMessage += System.lineSeparator();
@@ -510,7 +510,7 @@ public abstract class FileBinaryRequestExecutor {
         }
 
         // No results are produced. Throw the list of registered Exception.
-        String exceptionMessage = String.format("Unable to upload file binary to %s.",
+        String exceptionMessage = String.format(loggingPrefix + "Unable to upload file binary to %s.",
                 request.url().toString());
         if (catchedExceptions.size() > 0) { //add the details of the most recent exception.
             exceptionMessage += System.lineSeparator();


### PR DESCRIPTION
File binary upload: Add batch-level retry (and throttling) for stream reset exceptions. The batch will be re-tried a single item at a time.