### PR TITLE
Handle both cases with Async and Sync calls

### DIFF
--- a/src/main/java/com/cognite/client/Files.java
+++ b/src/main/java/com/cognite/client/Files.java
@@ -533,7 +533,7 @@ public abstract class Files extends ApiBase {
                 Throwable cause = e.getCause();
 
                 if (RETRYABLE_EXCEPTIONS_BINARY_UPLOAD.stream()
-                        .anyMatch(retryable -> retryable.isInstance(cause.getClass()))) {
+                        .anyMatch(retryable -> retryable.isInstance(cause))) {
                     // The API is most likely saturated. Retry the uploads one file at a time.
                     LOG.warn(batchLoggingPrefix + "Error when uploading the batch of file binaries. Will retry each file individually.");
                     for (FileContainer file : uploadBatch) {

--- a/src/main/java/com/cognite/client/servicesV1/executor/FileBinaryRequestExecutor.java
+++ b/src/main/java/com/cognite/client/servicesV1/executor/FileBinaryRequestExecutor.java
@@ -326,12 +326,8 @@ public abstract class FileBinaryRequestExecutor {
                 }
             } catch (Exception e) {
                 catchedExceptions.add(e);
-                // depends on the execution path either of two may happen:
-                // 1. async call failed and cause is packed with CompletionException
-                // 2. sync call (small file) throws a direct exception
-                final Throwable cause = e instanceof CompletionException ? e.getCause() : e;
                 // if we get a transient error, retry the call
-                if (RETRYABLE_EXCEPTIONS.stream().anyMatch(known -> known.isInstance(cause))
+                if (RETRYABLE_EXCEPTIONS.stream().anyMatch(known -> known.isInstance(e))
                         || RETRYABLE_RESPONSE_CODES.contains(responseCode)) {
                     LOG.warn(loggingPrefix + "Transient error when downloading file ("
                             + "response code: " + responseCode
@@ -499,11 +495,10 @@ public abstract class FileBinaryRequestExecutor {
             } catch (Exception e) {
                 catchedExceptions.add(e);
                 // depends on the execution path either of two may happen:
-                // 1. async call failed and cause is packed with CompletionException
-                // 2. sync call (small file) throws a direct exception
-                final Throwable cause = e instanceof CompletionException ? e.getCause() : e;
+                // 1. async call failed and cause is packed with CompletionException (will be handled outside)
+                // 2. sync call (small file) throws a direct exception should be handled here.
                 // if we get a transient error, retry the call
-                if (RETRYABLE_EXCEPTIONS.stream().anyMatch(known -> known.isInstance(cause))
+                if (RETRYABLE_EXCEPTIONS.stream().anyMatch(known -> known.isInstance(e))
                         || RETRYABLE_RESPONSE_CODES.contains(responseCode)) {
                     apiRetryCounter++;
                     LOG.warn(loggingPrefix + "Transient error when reading from Fusion (request id: " + requestId

--- a/src/main/java/com/cognite/client/servicesV1/executor/FileBinaryRequestExecutor.java
+++ b/src/main/java/com/cognite/client/servicesV1/executor/FileBinaryRequestExecutor.java
@@ -327,7 +327,7 @@ public abstract class FileBinaryRequestExecutor {
             } catch (Exception e) {
                 catchedExceptions.add(e);
                 // depends on the execution path either of two may happen:
-                // 1. async call failed and cause is packed with CompleteException
+                // 1. async call failed and cause is packed with CompletionException
                 // 2. sync call (small file) throws a direct exception
                 final Throwable cause = e instanceof CompletionException ? e.getCause() : e;
                 // if we get a transient error, retry the call
@@ -499,7 +499,7 @@ public abstract class FileBinaryRequestExecutor {
             } catch (Exception e) {
                 catchedExceptions.add(e);
                 // depends on the execution path either of two may happen:
-                // 1. async call failed and cause is packed with CompleteException
+                // 1. async call failed and cause is packed with CompletionException
                 // 2. sync call (small file) throws a direct exception
                 final Throwable cause = e instanceof CompletionException ? e.getCause() : e;
                 // if we get a transient error, retry the call

--- a/src/main/java/com/cognite/client/servicesV1/executor/FileBinaryRequestExecutor.java
+++ b/src/main/java/com/cognite/client/servicesV1/executor/FileBinaryRequestExecutor.java
@@ -503,7 +503,7 @@ public abstract class FileBinaryRequestExecutor {
                 // 2. sync call (small file) throws a direct exception
                 final Throwable cause = e instanceof CompletionException ? e.getCause() : e;
                 // if we get a transient error, retry the call
-                if (RETRYABLE_EXCEPTIONS.stream().anyMatch(known -> known.isInstance(cause.getClass()))
+                if (RETRYABLE_EXCEPTIONS.stream().anyMatch(known -> known.isInstance(cause))
                         || RETRYABLE_RESPONSE_CODES.contains(responseCode)) {
                     apiRetryCounter++;
                     LOG.warn(loggingPrefix + "Transient error when reading from Fusion (request id: " + requestId

--- a/src/main/java/com/cognite/client/servicesV1/executor/FileBinaryRequestExecutor.java
+++ b/src/main/java/com/cognite/client/servicesV1/executor/FileBinaryRequestExecutor.java
@@ -50,6 +50,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.*;
 
 /**
@@ -282,7 +283,7 @@ public abstract class FileBinaryRequestExecutor {
                 if (!response.isSuccessful() && !getValidResponseCodes().contains(responseCode)) {
                     String errorMessage = "Downloading file binary: Unexpected response code: " + responseCode + ". "
                             + response.toString() + System.lineSeparator()
-                            + "Response body: " + response.body().string() + System.lineSeparator()
+                            + "Response body: " + Objects.requireNonNull(response.body()).string() + System.lineSeparator()
                             + "Response headers: " + response.headers().toString() + System.lineSeparator();
 
                     if (responseCode >= 400 && responseCode < 500) {
@@ -296,37 +297,41 @@ public abstract class FileBinaryRequestExecutor {
                 // check the response
                 if (response.body() == null) {
                     throw new Exception(loggingPrefix + "Successful response, but the body is null. "
-                                                + response.toString() + System.lineSeparator()
-                                                + "Response headers: " + response.headers().toString());
+                            + response.toString() + System.lineSeparator()
+                            + "Response headers: " + response.headers().toString());
                 }
 
                 // check the content length. When downloading files >200MiB we will use temp storage.
-                if (response.body().contentLength() > (1024L * 1024L * 200L) || isForceTempStorage()) {
+                final long contentLength = Objects.requireNonNull(response.body()).contentLength();
+                if (contentLength > (1024L * 1024L * 200L) || isForceTempStorage()) {
                     if (null == getTempStoragePath()) {
                         String message = String.format("File too large to download to memory. Consider configuring temp "
                                         + "storage on the file reader.%n"
                                         + "Content-length = [%d]. %n"
                                         + "Response headers: %s",
-                                response.body().contentLength(),
+                                contentLength,
                                 response.headers().toString());
                         throw new IOException(message);
                     }
                     LOG.info("Downloading {} MiB to temp storage binary.",
-                            String.format("%.2f", response.body().contentLength() / (1024d * 1024d)));
+                            String.format("%.2f", contentLength / (1024d * 1024d)));
                     return downloadBinaryToTempStorage(response);
                 } else {
                     LOG.info("Downloading {} MiB to memory-based binary.",
-                            String.format("%.2f", response.body().contentLength() / (1024d * 1024d)));
+                            String.format("%.2f", contentLength / (1024d * 1024d)));
                     return FileBinary.newBuilder()
-                            .setBinary(ByteString.readFrom(response.body().byteStream()))
-                            .setContentLength(response.body().contentLength())
+                            .setBinary(ByteString.readFrom(Objects.requireNonNull(response.body()).byteStream()))
+                            .setContentLength(contentLength)
                             .build();
                 }
             } catch (Exception e) {
                 catchedExceptions.add(e);
-
+                // depends on the execution path either of two may happen:
+                // 1. async call failed and cause is packed with CompleteException
+                // 2. sync call (small file) throws a direct exception
+                final Throwable cause = e instanceof CompletionException ? e.getCause() : e;
                 // if we get a transient error, retry the call
-                if (RETRYABLE_EXCEPTIONS.stream().anyMatch(known -> known.isInstance(e.getClass()))
+                if (RETRYABLE_EXCEPTIONS.stream().anyMatch(known -> known.isInstance(cause))
                         || RETRYABLE_RESPONSE_CODES.contains(responseCode)) {
                     LOG.warn(loggingPrefix + "Transient error when downloading file ("
                             + "response code: " + responseCode
@@ -464,7 +469,7 @@ public abstract class FileBinaryRequestExecutor {
                 if (!response.isSuccessful() && !getValidResponseCodes().contains(responseCode)) {
                     String errorMessage = "Uploading file binary: Unexpected response code: " + responseCode + ". "
                             + response.toString() + System.lineSeparator()
-                            + "Response body: " + response.body().string() + System.lineSeparator()
+                            + "Response body: " + Objects.requireNonNull(response.body()).string() + System.lineSeparator()
                             + "Response headers: " + response.headers().toString() + System.lineSeparator();
 
                     throw new IOException(errorMessage);
@@ -478,11 +483,12 @@ public abstract class FileBinaryRequestExecutor {
 
                 // check the response content length. When downloading very large files this may exceed 4GB
                 // we put a limit of 200MiB on the response
-                if (response.body().contentLength() > (1024L * 1024L * 200L)) {
+                final long contentLength = Objects.requireNonNull(response.body()).contentLength();
+                if (contentLength > (1024L * 1024L * 200L)) {
                     String message = String.format("Response too large. "
                                     + "Content-length = [%d]. %n"
                                     + "Response headers: %s",
-                            response.body().contentLength(),
+                            contentLength,
                             response.headers().toString());
                     throw new IOException(message);
                 }
@@ -492,9 +498,12 @@ public abstract class FileBinaryRequestExecutor {
                         .withApiRetryCounter(apiRetryCounter);
             } catch (Exception e) {
                 catchedExceptions.add(e);
-
+                // depends on the execution path either of two may happen:
+                // 1. async call failed and cause is packed with CompleteException
+                // 2. sync call (small file) throws a direct exception
+                final Throwable cause = e instanceof CompletionException ? e.getCause() : e;
                 // if we get a transient error, retry the call
-                if (RETRYABLE_EXCEPTIONS.stream().anyMatch(known -> known.isInstance(e.getClass()))
+                if (RETRYABLE_EXCEPTIONS.stream().anyMatch(known -> known.isInstance(cause.getClass()))
                         || RETRYABLE_RESPONSE_CODES.contains(responseCode)) {
                     apiRetryCounter++;
                     LOG.warn(loggingPrefix + "Transient error when reading from Fusion (request id: " + requestId
@@ -570,7 +579,6 @@ public abstract class FileBinaryRequestExecutor {
             } catch (Exception e) {
                 // remove the temp file
                 cloudStorage.delete(blobId);
-
                 throw e;
             }
 

--- a/src/main/java/com/cognite/client/servicesV1/executor/RequestExecutor.java
+++ b/src/main/java/com/cognite/client/servicesV1/executor/RequestExecutor.java
@@ -241,7 +241,7 @@ public abstract class RequestExecutor {
             } catch (Exception e) {
                 catchedExceptions.add(e);
                 // depends on the execution path either of two may happen:
-                // 1. async call failed and cause is packed with CompleteException
+                // 1. async call failed and cause is packed with CompletionException
                 // 2. sync call (small file) throws a direct exception
                 final Throwable cause = e instanceof CompletionException ? e.getCause() : e;
                 // if we get a transient error, retry the call

--- a/src/main/java/com/cognite/client/servicesV1/executor/RequestExecutor.java
+++ b/src/main/java/com/cognite/client/servicesV1/executor/RequestExecutor.java
@@ -241,11 +241,10 @@ public abstract class RequestExecutor {
             } catch (Exception e) {
                 catchedExceptions.add(e);
                 // depends on the execution path either of two may happen:
-                // 1. async call failed and cause is packed with CompletionException
+                // 1. async call failed and cause is packed with CompletionException (will be handled outside)
                 // 2. sync call (small file) throws a direct exception
-                final Throwable cause = e instanceof CompletionException ? e.getCause() : e;
                 // if we get a transient error, retry the call
-                if (RETRYABLE_EXCEPTIONS.stream().anyMatch(known -> known.isInstance(cause))
+                if (RETRYABLE_EXCEPTIONS.stream().anyMatch(known -> known.isInstance(e))
                         || RETRYABLE_RESPONSE_CODES.contains(responseCode)) {
                     apiRetryCounter++;
                     LOG.warn(loggingPrefix + "Transient error when reading from Fusion (request id: " + requestId

--- a/src/main/java/com/cognite/client/servicesV1/executor/RequestExecutor.java
+++ b/src/main/java/com/cognite/client/servicesV1/executor/RequestExecutor.java
@@ -245,7 +245,7 @@ public abstract class RequestExecutor {
                 // 2. sync call (small file) throws a direct exception
                 final Throwable cause = e instanceof CompletionException ? e.getCause() : e;
                 // if we get a transient error, retry the call
-                if (RETRYABLE_EXCEPTIONS.stream().anyMatch(known -> known.isInstance(cause.getClass()))
+                if (RETRYABLE_EXCEPTIONS.stream().anyMatch(known -> known.isInstance(cause))
                         || RETRYABLE_RESPONSE_CODES.contains(responseCode)) {
                     apiRetryCounter++;
                     LOG.warn(loggingPrefix + "Transient error when reading from Fusion (request id: " + requestId


### PR DESCRIPTION
```  
exception: "java.lang.Exception: Batch: GHcGGy - Error when reading from Cognite Data Fusion.
	at com.cognite.beam.io.fn.read.RetrieveItemsBaseFn.processElement(RetrieveItemsBaseFn.java:93)
Caused by: java.util.concurrent.CompletionException: com.google.cloud.storage.StorageException: Read timed out
	at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:331)
	at java.base/java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:346)
	at java.base/java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:632)
	at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:506)
	at java.base/java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2088)
	at com.cognite.client.servicesV1.executor.FileBinaryRequestExecutor.lambda$downloadBinaryAsync$0(FileBinaryRequestExecutor.java:245)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: com.google.cloud.storage.StorageException: Read timed out
	at com.google.cloud.storage.spi.v1.HttpStorageRpc.translate(HttpStorageRpc.java:233)
	at com.google.cloud.storage.spi.v1.HttpStorageRpc.getCurrentUploadOffset(HttpStorageRpc.java:809)
```