### PR TITLE
Sequences max 10k cells

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
         <slf4j.version>1.7.32</slf4j.version>
         <guava.version>31.0.1-jre</guava.version>
         <commons.lang.version>3.12.0</commons.lang.version>
+        <logback.classic.version>1.2.8</logback.classic.version>
         <junit.version>5.7.2</junit.version>
 
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
@@ -153,7 +154,7 @@
        <dependency>
            <groupId>ch.qos.logback</groupId>
            <artifactId>logback-classic</artifactId>
-           <version>1.2.5</version>
+           <version>${logback.classic.version}</version>
            <scope>test</scope>
        </dependency>
         <dependency>

--- a/src/main/java/com/cognite/client/ApiBase.java
+++ b/src/main/java/com/cognite/client/ApiBase.java
@@ -1945,7 +1945,6 @@ abstract class ApiBase {
             Map<CompletableFuture<ResponseItems<String>>, List<T>> responseMap = new HashMap<>();
 
             // Split into batches
-            //List<List<T>> itemBatches = Partition.ofSize(items, getMaxBatchSize());
             List<List<T>> itemBatches = getBatchingFunction().apply(items);
 
             // Submit all batches

--- a/src/main/java/com/cognite/client/Sequences.java
+++ b/src/main/java/com/cognite/client/Sequences.java
@@ -28,10 +28,7 @@ import com.google.auto.value.AutoValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -166,7 +163,8 @@ public abstract class Sequences extends ApiBase {
         UpsertItems<SequenceMetadata> upsertItems = UpsertItems.of(createItemWriter, this::toRequestInsertItem, getClient().buildAuthConfig())
                 .withUpdateItemWriter(updateItemWriter)
                 .withUpdateMappingFunction(this::toRequestUpdateItem)
-                .withIdFunction(this::getSequenceId);
+                .withIdFunction(this::getSequenceId)
+                .withBatchingFunction(this::splitSequenceMetadataIntoBatches);
 
         if (getClient().getClientConfig().getUpsertMode() == UpsertMode.REPLACE) {
             upsertItems = upsertItems.withUpdateMappingFunction(this::toRequestReplaceItem);
@@ -193,6 +191,36 @@ public abstract class Sequences extends ApiBase {
         DeleteItems deleteItems = DeleteItems.of(deleteItemWriter, getClient().buildAuthConfig());
 
         return deleteItems.deleteItems(sequences);
+    }
+
+    /*
+    Custom batching function for upserting sequence headers/metadata. There are two limitations for the sequence header
+    batch size: 1) max no items = 1k and 2) max no cells/columns = 10k
+     */
+    private List<List<SequenceMetadata>> splitSequenceMetadataIntoBatches(List<SequenceMetadata> items) {
+        int MAX_CELLS_PER_BATCH = 10000;
+        int MAX_ITEMS_PER_BATCH = 1000;
+        List<List<SequenceMetadata>> batchList = new ArrayList<>();
+
+        int batchCellsCounter = 0;
+        List<SequenceMetadata> currentBatch = new ArrayList<>();
+        for (SequenceMetadata sequenceMetadata : items) {
+            if ((currentBatch.size() + 1 > MAX_ITEMS_PER_BATCH)
+                    || (batchCellsCounter + sequenceMetadata.getColumnsCount()) > MAX_CELLS_PER_BATCH) {
+                // We cannot add more items to the current batch. Start a new batch
+                batchList.add(currentBatch);
+                currentBatch.clear();
+                batchCellsCounter = 0;
+            }
+            // Add item to batch and bump the cell counter.
+            currentBatch.add(sequenceMetadata);
+            batchCellsCounter += sequenceMetadata.getColumnsCount();
+        }
+        if (currentBatch.size() > 0) {
+            // Add all remaining items
+            batchList.add(currentBatch);
+        }
+        return batchList;
     }
 
     /*

--- a/src/main/java/com/cognite/client/Sequences.java
+++ b/src/main/java/com/cognite/client/Sequences.java
@@ -209,7 +209,7 @@ public abstract class Sequences extends ApiBase {
                     || (batchCellsCounter + sequenceMetadata.getColumnsCount()) > MAX_CELLS_PER_BATCH) {
                 // We cannot add more items to the current batch. Start a new batch
                 batchList.add(currentBatch);
-                currentBatch.clear();
+                currentBatch = new ArrayList<>();
                 batchCellsCounter = 0;
             }
             // Add item to batch and bump the cell counter.

--- a/src/main/java/com/cognite/client/util/DataGenerator.java
+++ b/src/main/java/com/cognite/client/util/DataGenerator.java
@@ -83,7 +83,7 @@ public class DataGenerator {
             int noColumns = ThreadLocalRandom.current().nextInt(2,200);
             for (int j = 0; j < noColumns; j++) {
                 columns.add(SequenceColumn.newBuilder()
-                        .setExternalId(RandomStringUtils.randomAlphanumeric(20))
+                        .setExternalId(RandomStringUtils.randomAlphanumeric(50))
                         .setName("test_column_" + RandomStringUtils.randomAlphanumeric(5))
                         .setDescription(RandomStringUtils.randomAlphanumeric(50))
                         .setValueTypeValue(ThreadLocalRandom.current().nextInt(0,2))
@@ -91,7 +91,7 @@ public class DataGenerator {
             }
 
             objects.add(SequenceMetadata.newBuilder()
-                    .setExternalId(RandomStringUtils.randomAlphanumeric(10))
+                    .setExternalId(RandomStringUtils.randomAlphanumeric(20))
                     .setName("test_sequence_" + RandomStringUtils.randomAlphanumeric(5))
                     .setDescription(RandomStringUtils.randomAlphanumeric(50))
                     .putMetadata("type", DataGenerator.sourceValue)

--- a/src/test/java/com/cognite/client/SequencesTest.java
+++ b/src/test/java/com/cognite/client/SequencesTest.java
@@ -48,7 +48,7 @@ class SequencesTest {
 
         try {
             LOG.info(loggingPrefix + "Start upserting sequences.");
-            List<SequenceMetadata> upsertSequencesList = DataGenerator.generateSequenceMetadata(128);
+            List<SequenceMetadata> upsertSequencesList = DataGenerator.generateSequenceMetadata(153);
             client.sequences().upsert(upsertSequencesList);
             LOG.info(loggingPrefix + "Finished upserting sequences. Duration: {}",
                     Duration.between(startInstant, Instant.now()));


### PR DESCRIPTION
Fix batching of sequence headers to respect the limit of max 10k cells per batch