### PR TITLE
Add convenience method for specifying data sets

### DIFF
--- a/src/main/java/com/cognite/client/Request.java
+++ b/src/main/java/com/cognite/client/Request.java
@@ -221,6 +221,47 @@ public abstract class Request implements Serializable {
         return toBuilder().setRequestParameters(tempMapRoot).build();
     }
 
+
+    /**
+     * Convenience method for setting dataset external ids of a request.
+     *
+     * You can use this methods to limit a request to only include the resources within one or several
+     * specified data sets.
+     *
+     * @param externalId
+     * @return The request object with the parameter applied.
+     */
+    public Request withDatasetExternalIds(String... externalId) {
+        checkNotNull(externalId, "ExternalId cannot be null.");
+
+        List<Map<String, Object>> items = new ArrayList<>();
+        for (String element : externalId) {
+            items.add(Map.of("externalId", element));
+        }
+
+        return withFilterParameter("dataSetIds", items);
+    }
+
+    /**
+     * Convenience method for setting dataset internal ids of a request.
+     *
+     * You can use this methods to limit a request to only include the resources within one or several
+     * specified data sets.
+     *
+     * @param internalId
+     * @return The request object with the parameter applied.
+     */
+    public Request withDatasetIds(long... internalId) {
+        checkNotNull(internalId, "ExternalId cannot be null.");
+
+        List<Map<String, Object>> items = new ArrayList<>();
+        for (long element : internalId) {
+            items.add(Map.of("id", element));
+        }
+
+        return withFilterParameter("dataSetIds", items);
+    }
+
     /**
      * Convenience method for setting the external id for requesting an item.
      *

--- a/src/main/java/com/cognite/client/Request.java
+++ b/src/main/java/com/cognite/client/Request.java
@@ -243,7 +243,7 @@ public abstract class Request implements Serializable {
     }
 
     /**
-     * Convenience method for setting dataset internal ids of a request.
+     * Convenience method for setting dataset ids of a request.
      *
      * You can use this methods to limit a request to only include the resources within one or several
      * specified data sets.
@@ -252,7 +252,7 @@ public abstract class Request implements Serializable {
      * @return The request object with the parameter applied.
      */
     public Request withDatasetIds(long... internalId) {
-        checkNotNull(internalId, "ExternalId cannot be null.");
+        checkNotNull(internalId, "InternalId cannot be null.");
 
         List<Map<String, Object>> items = new ArrayList<>();
         for (long element : internalId) {


### PR DESCRIPTION
I found myself writing a variation of 
```java
Request.create()
     .withFilterParameter("dataSetIds", ImmutableList.of(
           ImmutableMap.of("externalId", dataSetExternalId)))
```
way too often (and thus having to introduce `google.common` libraries) in my files.

With this convenience method, the above now becomes
```java
Request.create()
    .withDatasetExternalIds(dataSetExternalId);
```

