### PR TITLE
Fix. Retry timeouts specifically--not all IOExceptions in general

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -19,6 +19,12 @@ Changes are grouped as follows:
 
 - Geo-location attribute and resource type.
 
+## [1.12.0-SNAPSHOT]
+
+### Fixed
+
+- File binary download. Expired URLs not retried properly.
+
 ## [1.11.0] 2022-02-18
 
 ### Added

--- a/src/main/java/com/cognite/client/servicesV1/executor/FileBinaryRequestExecutor.java
+++ b/src/main/java/com/cognite/client/servicesV1/executor/FileBinaryRequestExecutor.java
@@ -80,7 +80,7 @@ public abstract class FileBinaryRequestExecutor {
     );
 
     private static final ImmutableList<Class<? extends Exception>> RETRYABLE_EXCEPTIONS = ImmutableList.of(
-            IOException.class,
+            java.net.SocketTimeoutException.class,
             StreamResetException.class,
             com.google.cloud.storage.StorageException.class     // Timeout + stream reset when using GCS as temp storage
     );


### PR DESCRIPTION
When downloading binaries, the download URL will expire after a certain amount of time (ca. 30 secs). These situations are not propagated properly due to the generic IOException being captured by the request executor. This PR esures that the request executor only captures the timeout exceptions and allow the ClientRequestException (the expired URL) propagate up to Files and get retried properly.