### PR TITLE
Add upload limit of 1M UTF8 bytes to string time series.

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -21,6 +21,10 @@ Changes are grouped as follows:
 
 ## [1.12.0-SNAPSHOT]
 
+### Added
+
+- Write string data points. Write requests will chunk strings at 1M UTF8 bytes per request to respect API limits.
+
 ### Fixed
 
 - File binary download. Expired URLs not retried properly.

--- a/src/main/java/com/cognite/client/DataPoints.java
+++ b/src/main/java/com/cognite/client/DataPoints.java
@@ -812,7 +812,7 @@ public abstract class DataPoints extends ApiBase {
         List<List<TimeseriesPointPost>> batch = new ArrayList<>();
         int totalItemCounter = 0;
         int totalPointsCounter = 0;
-        int totalCharacterCounter = 0;
+        int totalUtf8ByteCounter = 0;
         int batchItemsCounter = 0;
         int batchPointsCounter = 0;
         int batchUtf8ByteCounter = 0;
@@ -840,7 +840,7 @@ public abstract class DataPoints extends ApiBase {
                 batchPointsCounter++;
                 totalPointsCounter++;
                 batchUtf8ByteCounter += getUtf8ByteCount(dataPoint);
-                totalCharacterCounter += getUtf8ByteCount(dataPoint);
+                totalUtf8ByteCounter += getUtf8ByteCount(dataPoint);
             }
             if (pointsList.size() > 0) {
                 batch.add(pointsList);
@@ -860,10 +860,10 @@ public abstract class DataPoints extends ApiBase {
             responseMap.put(upsertDataPoints(batch, dataPointsWriter), batch);
         }
 
-        LOG.debug(loggingPrefix + "Finished submitting {} data points with {} characters across {} TS items "
+        LOG.debug(loggingPrefix + "Finished submitting {} numeric data points and {} UTF-8 bytes across {} TS items "
                         + "in {} requests batches. Duration: {}",
                 totalPointsCounter,
-                totalCharacterCounter,
+                totalUtf8ByteCounter,
                 totalItemCounter,
                 responseMap.size(),
                 Duration.between(startInstant, Instant.now()));

--- a/src/main/java/com/cognite/client/DataPoints.java
+++ b/src/main/java/com/cognite/client/DataPoints.java
@@ -35,6 +35,7 @@ import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -53,7 +54,7 @@ public abstract class DataPoints extends ApiBase {
     // Write request batch limits
     private static final int DATA_POINTS_WRITE_MAX_ITEMS_PER_REQUEST = 10_000;
     private static final int DATA_POINTS_WRITE_MAX_POINTS_PER_REQUEST = 100_000;
-    private static final int DATA_POINTS_WRITE_MAX_CHARS_PER_REQUEST = 1_000_000;
+    private static final int DATA_POINTS_WRITE_MAX_UTF8_BYTES_PER_REQUEST = 1_000_000;
 
     // Read request limits
     private static final int MAX_RAW_POINTS = 100000;
@@ -633,7 +634,7 @@ public abstract class DataPoints extends ApiBase {
             if (itemsBatch.size() > 0) {
                 splitsByItems.add(requestParameters.withItems(itemsBatch));
             }
-            LOG.info(loggingPrefix + "Split the original {} request items across {} requests.",
+            LOG.info(loggingPrefix + "Split the original {} time series items across {} requests.",
                     requestParameters.getItems().size(),
                     splitsByItems.size());
         } else {
@@ -646,8 +647,8 @@ public abstract class DataPoints extends ApiBase {
         int capacity = Math.min(getClient().getClientConfig().getNoWorkers(),
                 getClient().getClientConfig().getNoListPartitions());
         if (splitsByItems.size() / (long) capacity > 0.6) {
-            LOG.info(loggingPrefix + "Splitting by items into {} requests offers good utilization of the available {} "
-                    + "capacity units. Will not split further (by time window).",
+            LOG.info(loggingPrefix + "Splitting by time series items into {} requests offers good utilization of the available {} "
+                    + "workers/partitions. Will not split further (by time window).",
                     splitsByItems.size(),
                     capacity);
             return splitsByItems;
@@ -814,14 +815,14 @@ public abstract class DataPoints extends ApiBase {
         int totalCharacterCounter = 0;
         int batchItemsCounter = 0;
         int batchPointsCounter = 0;
-        int batchCharacterCounter = 0;
+        int batchUtf8ByteCounter = 0;
         for (Map.Entry<String, List<TimeseriesPointPost>> entry : groupedPoints.entrySet()) {
             List<TimeseriesPointPost> pointsList = new ArrayList<>();
             for (TimeseriesPointPost dataPoint : entry.getValue()) {
                 // Check if the new data point will make the current batch too large.
                 // If yes, submit the batch before continuing the iteration.
                 if (batchPointsCounter + 1 >= DATA_POINTS_WRITE_MAX_POINTS_PER_REQUEST
-                        || batchCharacterCounter + getCharacterCount(dataPoint) >= DATA_POINTS_WRITE_MAX_CHARS_PER_REQUEST) {
+                        || batchUtf8ByteCounter + getUtf8ByteCount(dataPoint) >= DATA_POINTS_WRITE_MAX_UTF8_BYTES_PER_REQUEST) {
                     if (pointsList.size() > 0) {
                         // We have some points to add to the batch before submitting
                         batch.add(pointsList);
@@ -829,7 +830,7 @@ public abstract class DataPoints extends ApiBase {
                     }
                     responseMap.put(upsertDataPoints(batch, dataPointsWriter), batch);
                     batch = new ArrayList<>();
-                    batchCharacterCounter = 0;
+                    batchUtf8ByteCounter = 0;
                     batchItemsCounter = 0;
                     batchPointsCounter = 0;
                 }
@@ -838,8 +839,8 @@ public abstract class DataPoints extends ApiBase {
                 pointsList.add(dataPoint);
                 batchPointsCounter++;
                 totalPointsCounter++;
-                batchCharacterCounter += getCharacterCount(dataPoint);
-                totalCharacterCounter += getCharacterCount(dataPoint);
+                batchUtf8ByteCounter += getUtf8ByteCount(dataPoint);
+                totalCharacterCounter += getUtf8ByteCount(dataPoint);
             }
             if (pointsList.size() > 0) {
                 batch.add(pointsList);
@@ -850,7 +851,7 @@ public abstract class DataPoints extends ApiBase {
             if (batchItemsCounter >= DATA_POINTS_WRITE_MAX_ITEMS_PER_REQUEST) {
                 responseMap.put(upsertDataPoints(batch, dataPointsWriter), batch);
                 batch = new ArrayList<>();
-                batchCharacterCounter = 0;
+                batchUtf8ByteCounter = 0;
                 batchItemsCounter = 0;
                 batchPointsCounter = 0;
             }
@@ -1031,15 +1032,15 @@ public abstract class DataPoints extends ApiBase {
     }
 
     /**
-     * Returns the total character count. If it is a numeric data point, the count will be 0.
+     * Returns the UTF8 byte count for string data points. If it is a numeric data point, the count will be 0.
      *
      * @param point The data point to check for character count.
      * @return The number of string characters.
      */
-    private int getCharacterCount(TimeseriesPointPost point) {
+    private int getUtf8ByteCount(TimeseriesPointPost point) {
         int count = 0;
         if (point.getValueTypeCase() == TimeseriesPointPost.ValueTypeCase.VALUE_STRING) {
-            count = point.getValueString().length();
+            count = point.getValueString().getBytes(StandardCharsets.UTF_8).length;
         }
         return count;
     }


### PR DESCRIPTION
Add batching logic to string timeseries post/write. String time series data points should be max 1m UTF-8 bytes per request. Previously we just counted the number of characters (at 1M), but not the UTF-8 encoded length. 

This PR updates the batching logic to use UTF-8 byte length as a batching limit instead of number of characters.