### PR TITLE
Fix shaded dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target/
 .classpath
 .factorypath
 *.iml
+/dependency-reduced-pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -348,11 +348,11 @@
                         </goals>
                         <configuration>
                             <minimizeJar>false</minimizeJar>
-                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <createDependencyReducedPom>true</createDependencyReducedPom>
+                            <promoteTransitiveDependencies>true</promoteTransitiveDependencies>
                             <artifactSet>
                                 <includes>
                                     <include>com.squareup.okhttp3:okhttp</include>
-                                    <include>org.jetbrains.kotlin:kotlin-stdlib</include>
                                     <include>com.squareup.okio:okio</include>
                                 </includes>
                             </artifactSet>


### PR DESCRIPTION
I'd recommend against shading in the first place. But for now this a bugfix to fix some issues.

---

Remove Kotlin stdlib from shaded libraries, which were not relocated
causing it to conflict with other dependencies. Setting
promoteTransitiveDependencies ensure the Kotlin stdlib, being a
dependency of okhttp3, will be listed as a dependency and installed
by consumers.

Create and use a reduced pom, so the shaded dependencies are not also
specified as dependencies.