### PR TITLE
Simplify file upload writer

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -19,6 +19,11 @@ Changes are grouped as follows:
 
 - Geo-location attribute and resource type
 
+## [1.14.0-SNAPSHOT]
+
+### Fixed
+- File binary upload null pointer exception when running on Android devices.
+
 ## [1.13.2] 2022-04-12
 
 ### Fixed

--- a/src/main/java/com/cognite/client/servicesV1/executor/RequestExecutor.java
+++ b/src/main/java/com/cognite/client/servicesV1/executor/RequestExecutor.java
@@ -214,7 +214,7 @@ public abstract class RequestExecutor {
                 // if the call was not successful, throw an error
                 if (!response.isSuccessful() && !getValidResponseCodes().contains(responseCode)) {
                     throw new IOException(
-                            "Reading from Fusion: Unexpected response code: " + responseCode + ". "
+                            "Response from Fusion: Unexpected response code: " + responseCode + ". "
                                     + response.toString() + System.lineSeparator()
                                     + "Response body: " + response.body().string() + System.lineSeparator()
                                     + "Response headers: " + response.headers().toString() + System.lineSeparator()
@@ -222,7 +222,7 @@ public abstract class RequestExecutor {
                 }
                 // check the response
                 if (response.body() == null) {
-                    throw new Exception("Reading from Fusion: Successful response, but the body is null. "
+                    throw new Exception("Response from Fusion: Successful response, but the body is null. "
                                                 + response.toString() + System.lineSeparator()
                                                 + "Response headers: " + response.headers().toString());
                 }
@@ -248,13 +248,13 @@ public abstract class RequestExecutor {
                 if (RETRYABLE_EXCEPTIONS.stream().anyMatch(known -> known.isInstance(e))
                         || RETRYABLE_RESPONSE_CODES.contains(responseCode)) {
                     apiRetryCounter++;
-                    LOG.warn(loggingPrefix + "Transient error when reading from Fusion (request id: " + requestId
+                    LOG.warn(loggingPrefix + "Transient error when receiving response from Fusion (request id: " + requestId
                             + ", response code: " + responseCode
                             + "). Retrying...", e);
 
                 } else {
                     // not transient, just re-throw
-                    LOG.error(loggingPrefix + "Non-transient error occurred when reading from Fusion. Request id: " + requestId
+                    LOG.error(loggingPrefix + "Non-transient error occurred when receiving response from Fusion. Request id: " + requestId
                             + ", Response code: " + responseCode, e);
                     throw e;
                 }


### PR DESCRIPTION
Slightly simplify the file binary upload writer.
Removed the linked hashmap (produced by the Json parser).
Changed from async -> join to just sync on the post file header