### PR TITLE
Clean up entity matching endpoint

### DIFF
--- a/releases.md
+++ b/releases.md
@@ -17,6 +17,12 @@ Changes are grouped as follows:
 
 ### Short term
 
+## [1.17.0-SNAPSHOT]
+
+### Added
+
+- Configurable timeout for async api jobs (i.e. `entity matching` and `engineering diagram parsing`). Use `ClientConfig.withAsyncApiJobTimeout(Duration timeout)` to specify a custom timeout. The default timeout is 20 mins.
+
 ## [1.16.0] 2022-05-30
 
 ### Added

--- a/src/main/java/com/cognite/client/CogniteClient.java
+++ b/src/main/java/com/cognite/client/CogniteClient.java
@@ -571,9 +571,8 @@ public abstract class CogniteClient implements Serializable {
             cdfProject = loginStatus.getProject();
         }
 
-        return AuthConfig.create()
-                .withHost(getBaseUrl())
-                .withProject(cdfProject);
+        return AuthConfig.of(cdfProject)
+                .withHost(getBaseUrl());
     }
 
     /*

--- a/src/main/java/com/cognite/client/EntityMatching.java
+++ b/src/main/java/com/cognite/client/EntityMatching.java
@@ -80,7 +80,7 @@ public abstract class EntityMatching extends ApiBase {
      * The default number of matches is 1 and score threshold used for matching is 0.
      * @param modelExternalId The external id of the matching model to use.
      * @param sources A list of entities to match from. If the list is empty, the model training sources will be used.
-     * @param targets A list of entities to match to. If the list is empty, the model traning targets will be used.
+     * @param targets A list of entities to match to. If the list is empty, the model training targets will be used.
      * @return The entity matching results.
      * @throws Exception
      */
@@ -99,7 +99,7 @@ public abstract class EntityMatching extends ApiBase {
      * The default score threshold used for matching is 0.
      * @param modelExternalId The external id of the matching model to use.
      * @param sources A list of entities to match from. If the list is empty, the model training sources will be used.
-     * @param targets A list of entities to match to. If the list is empty, the model traning targets will be used.
+     * @param targets A list of entities to match to. If the list is empty, the model training targets will be used.
      * @param numMatches The maximum number of match candidates per source.
      * @return The entity matching results.
      * @throws Exception
@@ -119,7 +119,7 @@ public abstract class EntityMatching extends ApiBase {
      *
      * @param modelExternalId The external id of the matching model to use.
      * @param sources A list of entities to match from. If the list is empty, the model training sources will be used.
-     * @param targets A list of entities to match to. If the list is empty, the model traning targets will be used.
+     * @param targets A list of entities to match to. If the list is empty, the model training targets will be used.
      * @param numMatches The maximum number of match candidates per source.
      * @param scoreThreshold The minimum score required for a match candidate.
      * @return The entity matching results.
@@ -174,7 +174,7 @@ public abstract class EntityMatching extends ApiBase {
      * The default number of matches is 1 and score threshold used for matching is 0.
      * @param modelId The internal id of the matching model to use.
      * @param sources A list of entities to match from. If the list is empty, the model training sources will be used.
-     * @param targets A list of entities to match to. If the list is empty, the model traning targets will be used.
+     * @param targets A list of entities to match to. If the list is empty, the model training targets will be used.
      * @return The entity matching results.
      * @throws Exception
      */

--- a/src/main/java/com/cognite/client/config/AuthConfig.java
+++ b/src/main/java/com/cognite/client/config/AuthConfig.java
@@ -40,6 +40,11 @@ public abstract class AuthConfig implements Serializable {
   public static AuthConfig create() {
     return AuthConfig.builder().build();
   }
+  public static AuthConfig of(String cdfProject) {
+    return AuthConfig.builder()
+            .setProject(cdfProject)
+            .build();
+  }
 
   @Nullable public abstract String getProject();
   public abstract String getHost();

--- a/src/main/java/com/cognite/client/config/ClientConfig.java
+++ b/src/main/java/com/cognite/client/config/ClientConfig.java
@@ -4,7 +4,9 @@ import com.google.auto.value.AutoValue;
 import com.google.common.base.Preconditions;
 
 import java.io.Serializable;
+import java.time.Duration;
 
+import static com.cognite.client.servicesV1.ConnectorConstants.DEFAULT_ASYNC_API_JOB_POLLING_INTERVAL;
 import static com.google.common.base.Preconditions.checkArgument;
 
 /**
@@ -50,7 +52,8 @@ public abstract class ClientConfig implements Serializable {
                 .setNoWorkers(DEFAULT_CPU_THREADS)
                 .setNoListPartitions(DEFAULT_LIST_PARTITIONS)
                 .setUpsertMode(DEFAULT_UPSERT_MODE)
-                .setEntityMatchingMaxBatchSize(DEFAULT_ENTITY_MATCHING_MAX_BATCH_SIZE);
+                .setEntityMatchingMaxBatchSize(DEFAULT_ENTITY_MATCHING_MAX_BATCH_SIZE)
+                .setAsyncApiJobTimeout(DEFAULT_ASYNC_API_JOB_POLLING_INTERVAL);
     }
 
     /**
@@ -72,6 +75,7 @@ public abstract class ClientConfig implements Serializable {
     public abstract int getNoListPartitions();
     public abstract UpsertMode getUpsertMode();
     public abstract int getEntityMatchingMaxBatchSize();
+    public abstract Duration getAsyncApiJobTimeout();
 
     /**
      * Set the app identifier. The identifier is encoded in the api calls to the Cognite instance and can be
@@ -170,6 +174,10 @@ public abstract class ClientConfig implements Serializable {
         return toBuilder().setEntityMatchingMaxBatchSize(value).build();
     }
 
+    public ClientConfig withAsyncApiJobTimeout(Duration timeout) {
+        return toBuilder().setAsyncApiJobTimeout(timeout).build();
+    }
+
     @AutoValue.Builder
     static abstract class Builder {
         abstract Builder setSdkIdentifier(String value);
@@ -180,6 +188,7 @@ public abstract class ClientConfig implements Serializable {
         abstract Builder setNoListPartitions(int value);
         abstract Builder setUpsertMode(UpsertMode value);
         abstract Builder setEntityMatchingMaxBatchSize(int value);
+        abstract Builder setAsyncApiJobTimeout(Duration value);
 
         abstract ClientConfig build();
     }

--- a/src/main/java/com/cognite/client/servicesV1/ConnectorConstants.java
+++ b/src/main/java/com/cognite/client/servicesV1/ConnectorConstants.java
@@ -27,7 +27,7 @@ public final class ConnectorConstants {
     /*
     API request identifiers
      */
-    public final static String SDK_IDENTIFIER = "cdf-sdk-java-1.17.x";
+    public final static String SDK_IDENTIFIER = "cdf-sdk-java-1.x.x";
     public final static String DEFAULT_APP_IDENTIFIER = "cdf-sdk-java";
     public final static String DEFAULT_SESSION_IDENTIFIER = "cdf-sdk-java";
 

--- a/src/main/java/com/cognite/client/servicesV1/ConnectorConstants.java
+++ b/src/main/java/com/cognite/client/servicesV1/ConnectorConstants.java
@@ -40,7 +40,7 @@ public final class ConnectorConstants {
     public static final int MAX_MAX_RETRIES = 20;
     public static final String DEFAULT_ENDPOINT = "";
     public static final Duration DEFAULT_ASYNC_API_JOB_TIMEOUT = Duration.ofMinutes(20);
-    public static final Duration DEFAULT_ASYNC_API_JOB_POLLING_INTERVAL = Duration.ofSeconds(2);
+    public static final Duration DEFAULT_ASYNC_API_JOB_POLLING_INTERVAL = Duration.ofSeconds(4);
 
     /*
     Default batch sizes for api requests

--- a/src/main/java/com/cognite/client/servicesV1/ConnectorConstants.java
+++ b/src/main/java/com/cognite/client/servicesV1/ConnectorConstants.java
@@ -27,7 +27,7 @@ public final class ConnectorConstants {
     /*
     API request identifiers
      */
-    public final static String SDK_IDENTIFIER = "cdf-sdk-java-1.2.x";
+    public final static String SDK_IDENTIFIER = "cdf-sdk-java-1.17.x";
     public final static String DEFAULT_APP_IDENTIFIER = "cdf-sdk-java";
     public final static String DEFAULT_SESSION_IDENTIFIER = "cdf-sdk-java";
 
@@ -39,7 +39,7 @@ public final class ConnectorConstants {
     public static final int MIN_MAX_RETRIES = 1;
     public static final int MAX_MAX_RETRIES = 20;
     public static final String DEFAULT_ENDPOINT = "";
-    public static final Duration DEFAULT_ASYNC_API_JOB_TIMEOUT = Duration.ofMinutes(15);
+    public static final Duration DEFAULT_ASYNC_API_JOB_TIMEOUT = Duration.ofMinutes(20);
     public static final Duration DEFAULT_ASYNC_API_JOB_POLLING_INTERVAL = Duration.ofSeconds(2);
 
     /*

--- a/src/main/java/com/cognite/client/servicesV1/ConnectorServiceV1.java
+++ b/src/main/java/com/cognite/client/servicesV1/ConnectorServiceV1.java
@@ -2684,6 +2684,7 @@ public abstract class ConnectorServiceV1 implements Serializable {
                     .setRequestProvider(jobStartRequestProvider)
                     .setJobResultRequestProvider(jobResultRequestProvider)
                     .setResponseParser(responseParser)
+                    .setJobTimeoutDuration(client.getClientConfig().getAsyncApiJobTimeout())
                     .build();
         }
 
@@ -2718,22 +2719,6 @@ public abstract class ConnectorServiceV1 implements Serializable {
          */
         AsyncJobReader<T> withJobResultRequestProvider(RequestProvider requestProvider) {
             return toBuilder().setJobResultRequestProvider(requestProvider).build();
-        }
-
-        /**
-         * Sets the timeout for the api job. This reader will wait for up to the timeout duration for the api
-         * to complete the job.
-         *
-         * When the timeout is triggered, the reader will respond with the current job status (most likely
-         * "Queued" or "Running").
-         *
-         * The default timeout is 15 minutes.
-         *
-         * @param timeout
-         * @return
-         */
-        AsyncJobReader<T> withJobTimeout(Duration timeout) {
-            return toBuilder().setJobTimeoutDuration(timeout).build();
         }
 
         /**

--- a/src/main/java/com/cognite/client/servicesV1/ConnectorServiceV1.java
+++ b/src/main/java/com/cognite/client/servicesV1/ConnectorServiceV1.java
@@ -1676,8 +1676,6 @@ public abstract class ConnectorServiceV1 implements Serializable {
      * @return
      */
     public ItemReader<String> entityMatcherPredict() {
-        LOG.debug(loggingPrefix + "Initiating entity matcher predict service.");
-
         PostJsonRequestProvider jobStartRequestProvider =
                 PostJsonRequestProvider.builder()
                         .setEndpoint("context/entitymatching/predict")
@@ -1707,8 +1705,6 @@ public abstract class ConnectorServiceV1 implements Serializable {
      * @return
      */
     public Connector<String> entityMatcherFit() {
-        LOG.debug(loggingPrefix + "Initiating entity matcher training service.");
-
         PostJsonRequestProvider jobStartRequestProvider =
                 PostJsonRequestProvider.builder()
                         .setEndpoint("context/entitymatching")
@@ -1739,8 +1735,6 @@ public abstract class ConnectorServiceV1 implements Serializable {
      * @return
      */
     public Iterator<CompletableFuture<ResponseItems<String>>> readThreeDModels(Request queryParameters) {
-        LOG.debug(loggingPrefix + "Initiating read 3d models service.");
-
         ThreeDRequestProvider requestProvider = ThreeDRequestProvider.builder()
                 .setEndpoint("3d/models")
                 .setRequest(queryParameters)

--- a/src/test/java/com/cognite/client/EntityMatchingIntegrationTest.java
+++ b/src/test/java/com/cognite/client/EntityMatchingIntegrationTest.java
@@ -95,7 +95,7 @@ class EntityMatchingIntegrationTest {
         Request entityMatchFitRequest = Request.create()
                 .withRootParameter("sources",  source)
                 .withRootParameter("targets", target)
-                .withRootParameter("matchFields", Map.of("source", "name", "target", "externalId"))
+                .withRootParameter("matchFields", List.of(Map.of("source", "name", "target", "externalId")))
                 .withRootParameter("featureType", featureType);
 
         List<EntityMatchModel> models = client.contextualization().entityMatching()


### PR DESCRIPTION
Add configurable timeout to async api jobs (entity matching, P&ID parsing, etc.). Up until now, the SDK has used a fixed timeout of 15 mins, but this is too low in cases of high load on the CDF api. 

This PR makes the following changes:
- Make the async timeout configurable via ClientConfig.
- Up the default timeout to 20 mins. 
- Relax the async polling interval (towards the CDF api) from every 2 sec to every 4 sec. 
- Minor cleanup on comments, unused methods, etc. 