### PR TITLE
Add write queue

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,7 @@ map directly to the API's definitions.
 - [Client configuration. How to setup authentication.](clientSetup.md)
 - [Reading and writing data. All the basics of how to use the SDK](readAndWriteData.md)
 - [Streaming data from Cognite Data Fusion](streamingData.md)
+- [Utilities: make it easier writing extractors and data pipelines](utils.md)
 - [The Asset resource type. The secret sauce for handling the asset-hierarchy](assets.md)
 - [Relationships, powering the Cognite Data Fusion graph](relationships.md)
 - [Raw, flexible wide-column store](raw.md)

--- a/docs/utils.md
+++ b/docs/utils.md
@@ -1,0 +1,5 @@
+## Utilities: ease the development of extractors and data pipelines
+
+In addition to the [common read/write capabilities](readAndWriteData.md) you can also stream data from
+Cognite Data Fusion (CDF). CDF does not (yet) offer a native push interface so the SDK simulates streaming by regularly
+polling CDF for data updates and pushing these to the client. 

--- a/docs/utils.md
+++ b/docs/utils.md
@@ -1,5 +1,20 @@
 ## Utilities: ease the development of extractors and data pipelines
 
+The SDK hosts a set of utilities designed to make it easier for you to author extractors and/or data pipelines. The utilities resemble the Python SDK `extractor utils`.
+
+- Upload Queue
+
+### Upload Queue
+
+The UploadQueue batches together items and uploads them to Cognite Data Fusion (CDF). This helps improve performance and minimize the load on the CDF API.
+
+The queue is uploaded to CDF on three conditions:
+1) When the queue is 80% full.
+2) At a set interval (default is every 10 seconds).
+3) When the `upload()` method is called.
+
+
+
 In addition to the [common read/write capabilities](readAndWriteData.md) you can also stream data from
 Cognite Data Fusion (CDF). CDF does not (yet) offer a native push interface so the SDK simulates streaming by regularly
 polling CDF for data updates and pushing these to the client. 

--- a/docs/utils.md
+++ b/docs/utils.md
@@ -2,6 +2,7 @@
 
 The SDK hosts a set of utilities designed to make it easier for you to author extractors and/or data pipelines. The utilities resemble the Python SDK `extractor utils`.
 
+Utilities:
 - Upload Queue
 
 ### Upload Queue
@@ -13,21 +14,30 @@ The queue is uploaded to CDF on three conditions:
 2) At a set interval (default is every 10 seconds).
 3) When the `upload()` method is called.
 
-The queue is always uploaded when 80% full. This happens on a background thread so your client can keep putting items on the queue while the upload runs in the background. 
+The queue is always uploaded when 80% full. This happens on a background thread so your client can keep putting items on the queue while the upload runs in the background. The queue's capacity will help absorb spikes in the data flow and smooth them out before the CDF upload. However, you may find that your client put new items on the queue at a faster rate than the queue uploads--if this happens over time, the queue will start throttling your client by blocking the `put()` to allow the queue to drain.
 
 ```java
-// create a queue by calling uploadQueue() from the main api entry points
+// Create a queue by calling uploadQueue() from the main api entry points
 UploadQueue<Event, Event> eventUploadQueue = client.events().uploadQueue();
 
 UploadQueue<TimeseriesPointPost, TimeseriesPointPost> dataPointsUploadQueue = client.timeseries().dataPoints().uploadQueue();
 
+// The queue allows you to put items on it wihout blocking the calling thread--the items are uploaded to CDF 
+// in the background. You should add call-back functions so you can keep track of successful uploads and
+// capture exceptions in case of upload errors.
+UploadQueue<Event, Event> eventUploadQueue = client.events().uploadQueue()
         .withPostUploadFunction(events -> LOG.info("postUploadFunction triggered. Uploaded {} items", events.size()))
         .withExceptionHandlerFunction(exception -> LOG.warn("exceptionHandlerFunction triggered: {}", exception.getMessage()));
 ```
 
 To manually upload the contents of the queue, call the `upload()` method:
 ```java
-uploadQueue.upload();
+try {
+    // Please note that calling this method will block until all items in the queue have been uploaded
+    List<Event> uploadResults = eventUploadQueue.upload();
+} catch (Exception e) {
+    // In case an error happens during upload to CDF, upload() will throw an exception
+}
 ```
 
 A common pattern is to have the upload queue start a background timer to upload the queue at regular intervals. This ensures that the uploads are triggered both by maximum batch sizes (at the 80% queue fill rate) and at minimum time intervals.
@@ -44,12 +54,16 @@ while (my-client-has-work-to-do) {
     eventUploadQueue.put(my-event);
 }
 
-// When calling stop(), the background timer is stopped, and the entire queue is drained.
-// You should always close the queue after finishing writing to it.
+// Call stop() when you are finished putting items on the queue. This will stop the background timer, 
+// upload any remaining items in the queue and shut down the background threads. This allows the JVM to 
+// shut down cleanly when your code finishes executing.
 eventUploadQueue.stop();
 
-// You can also use the queue in a try-with-resources statement to ensure automatic resource clean-up
+// You can also use the queue in a try-with-resources statement to ensure automatic resource clean-up.
+// No need to call stop() explicitly as this automatically happens when the try statement finishes.
 final UploadQueue<Event, Event> eventUploadQueue = client.events().uploadQueue(); // the queue variable must be final 
+eventUploadQueue.start()
+        
 try (eventUploadQueue) {
     while (my-client-has-work-to-do) {
         eventUploadQueue.put(my-event);
@@ -58,12 +72,3 @@ try (eventUploadQueue) {
     
 }
 ```
-
-
-The queue's capacity will help absorb spikes in the data flow and smooth them out before the CDF upload. However, you may find that your client put new items on the queue at a faster rate than the queue uploads--if this happens over time, the queue will start throttling your client by blocking the `put()` to allow the queue to drain.
-
-
-
-In addition to the [common read/write capabilities](readAndWriteData.md) you can also stream data from
-Cognite Data Fusion (CDF). CDF does not (yet) offer a native push interface so the SDK simulates streaming by regularly
-polling CDF for data updates and pushing these to the client. 

--- a/docs/utils.md
+++ b/docs/utils.md
@@ -13,6 +13,55 @@ The queue is uploaded to CDF on three conditions:
 2) At a set interval (default is every 10 seconds).
 3) When the `upload()` method is called.
 
+The queue is always uploaded when 80% full. This happens on a background thread so your client can keep putting items on the queue while the upload runs in the background. 
+
+```java
+// create a queue by calling uploadQueue() from the main api entry points
+UploadQueue<Event, Event> eventUploadQueue = client.events().uploadQueue();
+
+UploadQueue<TimeseriesPointPost, TimeseriesPointPost> dataPointsUploadQueue = client.timeseries().dataPoints().uploadQueue();
+
+        .withPostUploadFunction(events -> LOG.info("postUploadFunction triggered. Uploaded {} items", events.size()))
+        .withExceptionHandlerFunction(exception -> LOG.warn("exceptionHandlerFunction triggered: {}", exception.getMessage()));
+```
+
+To manually upload the contents of the queue, call the `upload()` method:
+```java
+uploadQueue.upload();
+```
+
+A common pattern is to have the upload queue start a background timer to upload the queue at regular intervals. This ensures that the uploads are triggered both by maximum batch sizes (at the 80% queue fill rate) and at minimum time intervals.
+```java
+// create a queue by calling uploadQueue() from the main api entry points
+UploadQueue<Event, Event> eventUploadQueue = client.events().uploadQueue();
+
+// Start the background timer job. The default timer interval is 10 seconds. Remember to call stop() when you are
+// finished publishing items.
+eventUploadQueue.start();
+
+// publish your data items on the queue for upload
+while (my-client-has-work-to-do) {
+    eventUploadQueue.put(my-event);
+}
+
+// When calling stop(), the background timer is stopped, and the entire queue is drained.
+// You should always close the queue after finishing writing to it.
+eventUploadQueue.stop();
+
+// You can also use the queue in a try-with-resources statement to ensure automatic resource clean-up
+final UploadQueue<Event, Event> eventUploadQueue = client.events().uploadQueue(); // the queue variable must be final 
+try (eventUploadQueue) {
+    while (my-client-has-work-to-do) {
+        eventUploadQueue.put(my-event);
+    }
+} catch (Exception e) {
+    
+}
+```
+
+
+The queue's capacity will help absorb spikes in the data flow and smooth them out before the CDF upload. However, you may find that your client put new items on the queue at a faster rate than the queue uploads--if this happens over time, the queue will start throttling your client by blocking the `put()` to allow the queue to drain.
+
 
 
 In addition to the [common read/write capabilities](readAndWriteData.md) you can also stream data from

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,6 @@
     </scm>
 
     <properties>
-        <java.version>11</java.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -55,7 +54,7 @@
         <junit.version>5.8.2</junit.version>
         <mockito.version>4.6.1</mockito.version>
 
-        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
+        <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
         <maven-exec-plugin.version>3.0.0</maven-exec-plugin.version>
         <compiler.error.flag>-Werror</compiler.error.flag>
         <compiler.default.pkginfo.flag>-Xpkginfo:always</compiler.default.pkginfo.flag>
@@ -250,8 +249,6 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven-compiler-plugin.version}</version>
                 <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
                     <useIncrementalCompilation>false</useIncrementalCompilation>
                     <compilerArgs>
                         <arg>-Xlint:all</arg>

--- a/pom.xml
+++ b/pom.xml
@@ -340,7 +340,7 @@
                     <!--<excludedGroups>RemoteCDP, RemoteCDF</excludedGroups>-->
                 </configuration>
             </plugin>
-            <plugin>
+            <!--plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
                 <version>${maven-exec-plugin.version}</version>
@@ -353,7 +353,7 @@
                         </systemProperty>
                     </systemProperties>
                 </configuration>
-            </plugin>
+            </plugin-->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -257,9 +257,9 @@
                         <arg>-Xlint:-options</arg>
                         <!-- Temporary lint overrides, to be removed over time. -->
                         <!--arg>-Xlint:-cast</arg>
-                        <arg>-Xlint:-deprecation</arg>
+                        <arg>-Xlint:-deprecation</arg-->
                         <arg>-Xlint:-processing</arg>
-                        <arg>-Xlint:-rawtypes</arg>
+                        <!--arg>-Xlint:-rawtypes</arg>
                         <arg>-Xlint:-serial</arg>
                         <arg>-Xlint:-try</arg>
                         <arg>-Xlint:-unchecked</arg>

--- a/pom.xml
+++ b/pom.xml
@@ -42,8 +42,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <auto.version>1.9</auto.version>
-
-        <nimbusds.version>9.37.2</nimbusds.version>
+        <nimbusds.version>9.39</nimbusds.version>
         <awss3.version>1.12.266</awss3.version>
         <jgrapht.version>1.5.1</jgrapht.version>
         <okhttp3.version>4.10.0</okhttp3.version>
@@ -52,7 +51,7 @@
         <guava.version>31.1-jre</guava.version>
         <commons.lang.version>3.12.0</commons.lang.version>
         <logback.classic.version>1.2.11</logback.classic.version>
-        <junit.version>5.8.2</junit.version>
+        <junit.version>5.9.0</junit.version>
         <mockito.version>4.6.1</mockito.version>
 
         <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
@@ -64,7 +63,7 @@
         <!-- protobuf paths -->
         <protobuf.input.directory>${project.basedir}/src/main/proto</protobuf.input.directory>
         <protobuf.output.directory>${project.build.directory}/generated-sources/proto</protobuf.output.directory>
-        <protobuf.version>3.21.2</protobuf.version>
+        <protobuf.version>3.21.3</protobuf.version>
 
         <build-helper-maven-plugin.version>3.2.0</build-helper-maven-plugin.version>
         <maven-antrun-plugin.version>3.0.0</maven-antrun-plugin.version>
@@ -257,14 +256,14 @@
                         <!-- Override options warnings to support cross-compilation -->
                         <arg>-Xlint:-options</arg>
                         <!-- Temporary lint overrides, to be removed over time. -->
-                        <arg>-Xlint:-cast</arg>
+                        <!--arg>-Xlint:-cast</arg>
                         <arg>-Xlint:-deprecation</arg>
                         <arg>-Xlint:-processing</arg>
                         <arg>-Xlint:-rawtypes</arg>
                         <arg>-Xlint:-serial</arg>
                         <arg>-Xlint:-try</arg>
                         <arg>-Xlint:-unchecked</arg>
-                        <arg>-Xlint:-varargs</arg>
+                        <arg>-Xlint:-varargs</arg-->
                         <!-- Uncomment the following args to display more warnings. -->
                         <!-- -Xmaxwarns -->
                         <!-- 10000 -->

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <auto.version>1.9</auto.version>

--- a/releases.md
+++ b/releases.md
@@ -22,7 +22,7 @@ Changes are grouped as follows:
 ### Added
 
 - Configurable timeout for async api jobs (i.e. `entity matching` and `engineering diagram parsing`). Use `ClientConfig.withAsyncApiJobTimeout(Duration timeout)` to specify a custom timeout. The default timeout is 20 mins.
-- Support for configuring proxy server.
+- Support for configuring a proxy server: [Documentation](../docs/clientSetup.md#proxy-server).
 
 ### Changed
 

--- a/releases.md
+++ b/releases.md
@@ -23,6 +23,7 @@ Changes are grouped as follows:
 
 - Configurable timeout for async api jobs (i.e. `entity matching` and `engineering diagram parsing`). Use `ClientConfig.withAsyncApiJobTimeout(Duration timeout)` to specify a custom timeout. The default timeout is 20 mins.
 - Support for configuring a proxy server: [Documentation](../docs/clientSetup.md#proxy-server).
+- Added `UploadQueue` for various resource types to optimize data upload to Cognite Data Fusion.
 
 ### Changed
 

--- a/src/main/java/com/cognite/client/Assets.java
+++ b/src/main/java/com/cognite/client/Assets.java
@@ -21,6 +21,8 @@ import com.cognite.client.dto.Aggregate;
 import com.cognite.client.dto.Asset;
 import com.cognite.client.config.ResourceType;
 import com.cognite.client.dto.Item;
+import com.cognite.client.queue.UploadQueue;
+import com.cognite.client.queue.UpsertTarget;
 import com.cognite.client.servicesV1.ConnectorServiceV1;
 import com.cognite.client.servicesV1.parser.AssetParser;
 import com.cognite.client.stream.ListSource;
@@ -51,7 +53,7 @@ import java.util.stream.Stream;
  * It provides methods for reading and writing {@link com.cognite.client.dto.Asset}.
  */
 @AutoValue
-public abstract class Assets extends ApiBase implements ListSource<Asset> {
+public abstract class Assets extends ApiBase implements ListSource<Asset>, UpsertTarget<Asset> {
     private final static int MAX_UPSERT_BATCH_SIZE = 200;
 
     private static Builder builder() {
@@ -582,6 +584,16 @@ public abstract class Assets extends ApiBase implements ListSource<Asset> {
         return assetUpsertResults.stream()
                 .map(this::parseAsset)
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * Returns an upload queue.
+     *
+     * The upload queue helps improve performance by batching items together before uploading them to Cognite Data Fusion.
+     * @return The upload queue.
+     */
+    public UploadQueue<Asset> uploadQueue() {
+        return UploadQueue.of(this);
     }
 
     /**

--- a/src/main/java/com/cognite/client/Assets.java
+++ b/src/main/java/com/cognite/client/Assets.java
@@ -587,16 +587,6 @@ public abstract class Assets extends ApiBase implements ListSource<Asset>, Upser
     }
 
     /**
-     * Returns an upload queue.
-     *
-     * The upload queue helps improve performance by batching items together before uploading them to Cognite Data Fusion.
-     * @return The upload queue.
-     */
-    public UploadQueue<Asset> uploadQueue() {
-        return UploadQueue.of(this);
-    }
-
-    /**
      * Checks a collection of assets for integrity. The assets must represent a single, complete
      * hierarchy.
      *

--- a/src/main/java/com/cognite/client/Assets.java
+++ b/src/main/java/com/cognite/client/Assets.java
@@ -53,7 +53,7 @@ import java.util.stream.Stream;
  * It provides methods for reading and writing {@link com.cognite.client.dto.Asset}.
  */
 @AutoValue
-public abstract class Assets extends ApiBase implements ListSource<Asset>, UpsertTarget<Asset> {
+public abstract class Assets extends ApiBase implements ListSource<Asset> {
     private final static int MAX_UPSERT_BATCH_SIZE = 200;
 
     private static Builder builder() {

--- a/src/main/java/com/cognite/client/DataPoints.java
+++ b/src/main/java/com/cognite/client/DataPoints.java
@@ -452,6 +452,8 @@ public abstract class DataPoints extends ApiBase implements UpsertTarget<Timeser
      * Returns an upload queue.
      *
      * The upload queue helps improve performance by batching items together before uploading them to Cognite Data Fusion.
+     *
+     * This queue is tuned with a capacity of 500k elements for high-throughput data points.
      * @return The upload queue.
      */
     public UploadQueue<TimeseriesPointPost> uploadQueue() {

--- a/src/main/java/com/cognite/client/DataPoints.java
+++ b/src/main/java/com/cognite/client/DataPoints.java
@@ -17,6 +17,8 @@
 package com.cognite.client;
 
 import com.cognite.client.dto.*;
+import com.cognite.client.queue.UploadQueue;
+import com.cognite.client.queue.UpsertTarget;
 import com.cognite.client.servicesV1.ConnectorConstants;
 import com.cognite.client.servicesV1.ConnectorServiceV1;
 import com.cognite.client.servicesV1.ItemReader;
@@ -50,7 +52,7 @@ import java.util.stream.Collectors;
  * It provides methods for reading {@link TimeseriesPoint} and writing {@link TimeseriesPointPost}.
  */
 @AutoValue
-public abstract class DataPoints extends ApiBase {
+public abstract class DataPoints extends ApiBase implements UpsertTarget<TimeseriesPointPost> {
     // Write request batch limits
     private static final int DATA_POINTS_WRITE_MAX_ITEMS_PER_REQUEST = 10_000;
     private static final int DATA_POINTS_WRITE_MAX_POINTS_PER_REQUEST = 100_000;
@@ -426,6 +428,16 @@ public abstract class DataPoints extends ApiBase {
                         .orElse(0.0d)));
 
         return dataPoints;
+    }
+
+    /**
+     * Returns an upload queue.
+     *
+     * The upload queue helps improve performance by batching items together before uploading them to Cognite Data Fusion.
+     * @return The upload queue.
+     */
+    public UploadQueue<TimeseriesPointPost> uploadQueue() {
+        return UploadQueue.of(this);
     }
 
     /**

--- a/src/main/java/com/cognite/client/DataPoints.java
+++ b/src/main/java/com/cognite/client/DataPoints.java
@@ -52,7 +52,7 @@ import java.util.stream.Collectors;
  * It provides methods for reading {@link TimeseriesPoint} and writing {@link TimeseriesPointPost}.
  */
 @AutoValue
-public abstract class DataPoints extends ApiBase implements UpsertTarget<TimeseriesPointPost> {
+public abstract class DataPoints extends ApiBase implements UpsertTarget<TimeseriesPointPost, TimeseriesPointPost> {
     // Write request batch limits
     private static final int DATA_POINTS_WRITE_MAX_ITEMS_PER_REQUEST = 10_000;
     private static final int DATA_POINTS_WRITE_MAX_POINTS_PER_REQUEST = 100_000;
@@ -456,7 +456,7 @@ public abstract class DataPoints extends ApiBase implements UpsertTarget<Timeser
      * This queue is tuned with a capacity of 500k elements for high-throughput data points.
      * @return The upload queue.
      */
-    public UploadQueue<TimeseriesPointPost> uploadQueue() {
+    public UploadQueue<TimeseriesPointPost, TimeseriesPointPost> uploadQueue() {
         return UploadQueue.of(this)
                 .withQueueSize(500_000);
     }

--- a/src/main/java/com/cognite/client/Events.java
+++ b/src/main/java/com/cognite/client/Events.java
@@ -20,6 +20,7 @@ import com.cognite.client.dto.Aggregate;
 import com.cognite.client.dto.Event;
 import com.cognite.client.dto.Item;
 import com.cognite.client.config.ResourceType;
+import com.cognite.client.queue.UploadQueue;
 import com.cognite.client.queue.UpsertTarget;
 import com.cognite.client.servicesV1.ConnectorServiceV1;
 import com.cognite.client.servicesV1.parser.EventParser;
@@ -328,6 +329,14 @@ public abstract class Events extends ApiBase implements ListSource<Event>, Upser
         return upsertItems.upsertViaCreateAndUpdate(events).stream()
                 .map(this::parseEvent)
                 .collect(Collectors.toList());
+    }
+
+    /**
+     *
+     * @return
+     */
+    public UploadQueue<Event> uploadQueue() {
+        return UploadQueue.of(this);
     }
 
     /**

--- a/src/main/java/com/cognite/client/Events.java
+++ b/src/main/java/com/cognite/client/Events.java
@@ -332,8 +332,10 @@ public abstract class Events extends ApiBase implements ListSource<Event>, Upser
     }
 
     /**
+     * Returns an upload queue.
      *
-     * @return
+     * The upload queue helps improve performance by batching items together before uploading them to Cognite Data Fusion.
+     * @return The upload queue.
      */
     public UploadQueue<Event> uploadQueue() {
         return UploadQueue.of(this);

--- a/src/main/java/com/cognite/client/Events.java
+++ b/src/main/java/com/cognite/client/Events.java
@@ -20,6 +20,7 @@ import com.cognite.client.dto.Aggregate;
 import com.cognite.client.dto.Event;
 import com.cognite.client.dto.Item;
 import com.cognite.client.config.ResourceType;
+import com.cognite.client.queue.UpsertTarget;
 import com.cognite.client.servicesV1.ConnectorServiceV1;
 import com.cognite.client.servicesV1.parser.EventParser;
 import com.cognite.client.config.UpsertMode;
@@ -39,7 +40,7 @@ import java.util.stream.Collectors;
  * It provides methods for reading and writing {@link Event}.
  */
 @AutoValue
-public abstract class Events extends ApiBase implements ListSource<Event> {
+public abstract class Events extends ApiBase implements ListSource<Event>, UpsertTarget<Event> {
 
     private static Builder builder() {
         return new AutoValue_Events.Builder();

--- a/src/main/java/com/cognite/client/Events.java
+++ b/src/main/java/com/cognite/client/Events.java
@@ -41,7 +41,7 @@ import java.util.stream.Collectors;
  * It provides methods for reading and writing {@link Event}.
  */
 @AutoValue
-public abstract class Events extends ApiBase implements ListSource<Event>, UpsertTarget<Event> {
+public abstract class Events extends ApiBase implements ListSource<Event>, UpsertTarget<Event, Event> {
 
     private static Builder builder() {
         return new AutoValue_Events.Builder();
@@ -337,7 +337,7 @@ public abstract class Events extends ApiBase implements ListSource<Event>, Upser
      * The upload queue helps improve performance by batching items together before uploading them to Cognite Data Fusion.
      * @return The upload queue.
      */
-    public UploadQueue<Event> uploadQueue() {
+    public UploadQueue<Event, Event> uploadQueue() {
         return UploadQueue.of(this);
     }
 

--- a/src/main/java/com/cognite/client/Files.java
+++ b/src/main/java/com/cognite/client/Files.java
@@ -57,7 +57,8 @@ import java.util.stream.Collectors;
  * It provides methods for reading and writing {@link Event}.
  */
 @AutoValue
-public abstract class Files extends ApiBase implements UpsertTarget<FileMetadata> {
+public abstract class Files extends ApiBase
+        implements UpsertTarget<FileMetadata, FileMetadata>, UploadTarget<FileContainer, FileMetadata> {
     private static final int MAX_WRITE_REQUEST_BATCH_SIZE = 100;
     private static final int MAX_DOWNLOAD_BINARY_BATCH_SIZE = 10;
     private static final int MAX_UPLOAD_BINARY_BATCH_SIZE = 10;
@@ -588,14 +589,30 @@ public abstract class Files extends ApiBase implements UpsertTarget<FileMetadata
     }
 
     /**
-     * Returns an upload queue.
+     * Returns an upload queue for {@link FileMetadata}.
+     *
+     * You can use this queue to push file header/metadata updates to files that have already been uploaded to CDF.
      *
      * The upload queue helps improve performance by batching items together before uploading them to Cognite Data Fusion.
      * @return The upload queue.
      */
-    public UploadQueue<FileMetadata> metadataUploadQueue() {
-        return UploadQueue.of(this)
+    public UploadQueue<FileMetadata, FileMetadata> metadataUploadQueue() {
+        return UploadQueue.of((UpsertTarget) this)
                 .withQueueSize(100);
+    }
+
+    /**
+     * Returns an upload queue for {@link FileContainer}.
+     *
+     * You can use this queue to push file binaries and headers ({@link FileContainer}) to CDF.
+     *
+     * The upload queue helps improve performance by batching items together before uploading them to Cognite Data Fusion.
+     * @return The upload queue.
+     */
+    public UploadQueue<FileContainer, FileMetadata> fileContainerUploadQueue() {
+        return UploadQueue.of((UploadTarget) this)
+                .withQueueSize(10)
+                .withMaxUploadInterval(Duration.ofSeconds(30));
     }
 
     /**

--- a/src/main/java/com/cognite/client/Files.java
+++ b/src/main/java/com/cognite/client/Files.java
@@ -19,6 +19,9 @@ package com.cognite.client;
 import com.cognite.client.config.ResourceType;
 import com.cognite.client.config.UpsertMode;
 import com.cognite.client.dto.*;
+import com.cognite.client.queue.UploadQueue;
+import com.cognite.client.queue.UploadTarget;
+import com.cognite.client.queue.UpsertTarget;
 import com.cognite.client.servicesV1.ConnectorServiceV1;
 import com.cognite.client.servicesV1.ResponseItems;
 import com.cognite.client.servicesV1.executor.FileBinaryRequestExecutor;
@@ -54,7 +57,7 @@ import java.util.stream.Collectors;
  * It provides methods for reading and writing {@link Event}.
  */
 @AutoValue
-public abstract class Files extends ApiBase {
+public abstract class Files extends ApiBase implements UpsertTarget<FileMetadata> {
     private static final int MAX_WRITE_REQUEST_BATCH_SIZE = 100;
     private static final int MAX_DOWNLOAD_BINARY_BATCH_SIZE = 10;
     private static final int MAX_UPLOAD_BINARY_BATCH_SIZE = 10;
@@ -582,6 +585,17 @@ public abstract class Files extends ApiBase {
         return elementListCompleted.stream()
                 .map(this::parseFileMetadata)
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * Returns an upload queue.
+     *
+     * The upload queue helps improve performance by batching items together before uploading them to Cognite Data Fusion.
+     * @return The upload queue.
+     */
+    public UploadQueue<FileMetadata> metadataUploadQueue() {
+        return UploadQueue.of(this)
+                .withQueueSize(100);
     }
 
     /**

--- a/src/main/java/com/cognite/client/RawRows.java
+++ b/src/main/java/com/cognite/client/RawRows.java
@@ -48,7 +48,7 @@ import java.util.stream.Collectors;
  * It provides methods for interacting with the Raw row endpoint.
  */
 @AutoValue
-public abstract class RawRows extends ApiBase implements UpsertTarget<RawRow> {
+public abstract class RawRows extends ApiBase implements UpsertTarget<RawRow, RawRow> {
     private static final int MAX_WRITE_BATCH_SIZE = 1000;
     private static final int MAX_DELETE_BATCH_SIZE = 1000;
 
@@ -679,7 +679,7 @@ public abstract class RawRows extends ApiBase implements UpsertTarget<RawRow> {
      * The upload queue helps improve performance by batching items together before uploading them to Cognite Data Fusion.
      * @return The upload queue.
      */
-    public UploadQueue<RawRow> uploadQueue() {
+    public UploadQueue<RawRow, RawRow> uploadQueue() {
         return UploadQueue.of(this);
     }
 

--- a/src/main/java/com/cognite/client/Relationships.java
+++ b/src/main/java/com/cognite/client/Relationships.java
@@ -16,10 +16,13 @@
 
 package com.cognite.client;
 
+import com.amazonaws.services.s3.transfer.Upload;
 import com.cognite.client.config.ResourceType;
 import com.cognite.client.config.UpsertMode;
 import com.cognite.client.dto.Item;
 import com.cognite.client.dto.Relationship;
+import com.cognite.client.queue.UploadQueue;
+import com.cognite.client.queue.UpsertTarget;
 import com.cognite.client.servicesV1.ConnectorServiceV1;
 import com.cognite.client.servicesV1.parser.RelationshipParser;
 import com.cognite.client.util.Items;
@@ -36,7 +39,7 @@ import java.util.stream.Collectors;
  * It provides methods for reading and writing {@link Relationship}.
  */
 @AutoValue
-public abstract class Relationships extends ApiBase {
+public abstract class Relationships extends ApiBase implements UpsertTarget<Relationship> {
 
     private static Builder builder() {
         return new AutoValue_Relationships.Builder();
@@ -300,6 +303,16 @@ public abstract class Relationships extends ApiBase {
         return upsertItems.upsertViaCreateAndUpdate(relationships).stream()
                 .map(this::parseRelationship)
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * Returns an upload queue.
+     *
+     * The upload queue helps improve performance by batching items together before uploading them to Cognite Data Fusion.
+     * @return The upload queue.
+     */
+    public UploadQueue<Relationship> uploadQueue() {
+        return UploadQueue.of(this);
     }
 
     /**

--- a/src/main/java/com/cognite/client/Relationships.java
+++ b/src/main/java/com/cognite/client/Relationships.java
@@ -39,7 +39,7 @@ import java.util.stream.Collectors;
  * It provides methods for reading and writing {@link Relationship}.
  */
 @AutoValue
-public abstract class Relationships extends ApiBase implements UpsertTarget<Relationship> {
+public abstract class Relationships extends ApiBase implements UpsertTarget<Relationship, Relationship> {
 
     private static Builder builder() {
         return new AutoValue_Relationships.Builder();
@@ -311,7 +311,7 @@ public abstract class Relationships extends ApiBase implements UpsertTarget<Rela
      * The upload queue helps improve performance by batching items together before uploading them to Cognite Data Fusion.
      * @return The upload queue.
      */
-    public UploadQueue<Relationship> uploadQueue() {
+    public UploadQueue<Relationship, Relationship> uploadQueue() {
         return UploadQueue.of(this);
     }
 

--- a/src/main/java/com/cognite/client/SequenceRows.java
+++ b/src/main/java/com/cognite/client/SequenceRows.java
@@ -51,7 +51,7 @@ import static com.cognite.client.servicesV1.ConnectorConstants.*;
  * It provides methods for reading and writing {@link SequenceBody}.
  */
 @AutoValue
-public abstract class SequenceRows extends ApiBase implements UpsertTarget<SequenceBody> {
+public abstract class SequenceRows extends ApiBase implements UpsertTarget<SequenceBody, SequenceBody> {
     private static final SequenceMetadata DEFAULT_SEQ_METADATA = SequenceMetadata.newBuilder()
             .setExternalId("SDK_default")
             .setName("SDK_default")
@@ -466,7 +466,7 @@ public abstract class SequenceRows extends ApiBase implements UpsertTarget<Seque
      * {@link SequenceBody} objects are quite large, so the queue is tuned with a default size of 10.
      * @return The upload queue.
      */
-    public UploadQueue<SequenceBody> uploadQueue() {
+    public UploadQueue<SequenceBody, SequenceBody> uploadQueue() {
         return UploadQueue.of(this)
                 .withQueueSize(10);
     }

--- a/src/main/java/com/cognite/client/Sequences.java
+++ b/src/main/java/com/cognite/client/Sequences.java
@@ -40,7 +40,7 @@ import java.util.stream.Collectors;
  * It provides for reading an writing {@link SequenceMetadata}
  */
 @AutoValue
-public abstract class Sequences extends ApiBase implements UpsertTarget<SequenceMetadata> {
+public abstract class Sequences extends ApiBase implements UpsertTarget<SequenceMetadata, SequenceMetadata> {
 
     private static Builder builder() {
         return new AutoValue_Sequences.Builder();
@@ -323,7 +323,7 @@ public abstract class Sequences extends ApiBase implements UpsertTarget<Sequence
      * The upload queue helps improve performance by batching items together before uploading them to Cognite Data Fusion.
      * @return The upload queue.
      */
-    public UploadQueue<SequenceMetadata> uploadQueue() {
+    public UploadQueue<SequenceMetadata, SequenceMetadata> uploadQueue() {
         return UploadQueue.of(this);
     }
 

--- a/src/main/java/com/cognite/client/Sequences.java
+++ b/src/main/java/com/cognite/client/Sequences.java
@@ -22,6 +22,8 @@ import com.cognite.client.dto.Aggregate;
 import com.cognite.client.dto.DataSet;
 import com.cognite.client.dto.SequenceMetadata;
 import com.cognite.client.dto.Item;
+import com.cognite.client.queue.UploadQueue;
+import com.cognite.client.queue.UpsertTarget;
 import com.cognite.client.servicesV1.ConnectorServiceV1;
 import com.cognite.client.servicesV1.parser.SequenceParser;
 import com.cognite.client.util.Items;
@@ -38,7 +40,7 @@ import java.util.stream.Collectors;
  * It provides for reading an writing {@link SequenceMetadata}
  */
 @AutoValue
-public abstract class Sequences extends ApiBase {
+public abstract class Sequences extends ApiBase implements UpsertTarget<SequenceMetadata> {
 
     private static Builder builder() {
         return new AutoValue_Sequences.Builder();
@@ -313,6 +315,16 @@ public abstract class Sequences extends ApiBase {
         return upsertItems.upsertViaGetCreateAndUpdateDiff(sequences).stream()
                 .map(this::parseSequences)
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * Returns an upload queue.
+     *
+     * The upload queue helps improve performance by batching items together before uploading them to Cognite Data Fusion.
+     * @return The upload queue.
+     */
+    public UploadQueue<SequenceMetadata> uploadQueue() {
+        return UploadQueue.of(this);
     }
 
     /**

--- a/src/main/java/com/cognite/client/Timeseries.java
+++ b/src/main/java/com/cognite/client/Timeseries.java
@@ -42,7 +42,7 @@ import java.util.stream.Collectors;
  * It provides methods for reading and writing {@link TimeseriesMetadata}.
  */
 @AutoValue
-public abstract class Timeseries extends ApiBase implements UpsertTarget<TimeseriesMetadata> {
+public abstract class Timeseries extends ApiBase implements UpsertTarget<TimeseriesMetadata, TimeseriesMetadata> {
 
     private static Builder builder() {
         return new AutoValue_Timeseries.Builder();
@@ -321,7 +321,7 @@ public abstract class Timeseries extends ApiBase implements UpsertTarget<Timeser
      * The upload queue helps improve performance by batching items together before uploading them to Cognite Data Fusion.
      * @return The upload queue.
      */
-    public UploadQueue<TimeseriesMetadata> uploadQueue() {
+    public UploadQueue<TimeseriesMetadata, TimeseriesMetadata> uploadQueue() {
         return UploadQueue.of(this);
     }
 

--- a/src/main/java/com/cognite/client/Timeseries.java
+++ b/src/main/java/com/cognite/client/Timeseries.java
@@ -21,6 +21,8 @@ import com.cognite.client.config.UpsertMode;
 import com.cognite.client.dto.Aggregate;
 import com.cognite.client.dto.TimeseriesMetadata;
 import com.cognite.client.dto.Item;
+import com.cognite.client.queue.UploadQueue;
+import com.cognite.client.queue.UpsertTarget;
 import com.cognite.client.servicesV1.ConnectorServiceV1;
 import com.cognite.client.servicesV1.parser.TimeseriesParser;
 import com.cognite.client.util.Items;
@@ -40,7 +42,7 @@ import java.util.stream.Collectors;
  * It provides methods for reading and writing {@link TimeseriesMetadata}.
  */
 @AutoValue
-public abstract class Timeseries extends ApiBase {
+public abstract class Timeseries extends ApiBase implements UpsertTarget<TimeseriesMetadata> {
 
     private static Builder builder() {
         return new AutoValue_Timeseries.Builder();
@@ -311,6 +313,16 @@ public abstract class Timeseries extends ApiBase {
         return upsertItems.upsertViaCreateAndUpdate(timeseries).stream()
                 .map(this::parseTimeseries)
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * Returns an upload queue.
+     *
+     * The upload queue helps improve performance by batching items together before uploading them to Cognite Data Fusion.
+     * @return The upload queue.
+     */
+    public UploadQueue<TimeseriesMetadata> uploadQueue() {
+        return UploadQueue.of(this);
     }
 
     /**

--- a/src/main/java/com/cognite/client/queue/UploadQueue.java
+++ b/src/main/java/com/cognite/client/queue/UploadQueue.java
@@ -133,12 +133,14 @@ public abstract class UploadQueue<T> {
     }
 
     /**
-     * Uploads the queue and calls the post upload function if applicable.
+     * Uploads the current elements in the queue.
      *
+     * This method will block the calling thread until the upload operation completes.
+     *
+     * @return The uploaded objects.
      * @throws Exception in case of an error during the upload.
      */
-    public boolean upload() throws Exception {
-        boolean returnValue = true;
+    public List<T> upload() throws Exception {
         List<T> uploadBatch = new ArrayList<>(getQueue().size());
         List<T> uploadResults = new ArrayList<>(getQueue().size());
 
@@ -148,16 +150,9 @@ public abstract class UploadQueue<T> {
         // upload to the configured target
         if (null != getUpsertTarget()) {
             uploadResults = getUpsertTarget().upsert(uploadBatch);
-        } else {
-            returnValue = false;
         }
 
-        // Call the post upload function if applicable
-        if (null != getPostUploadFunction()) {
-            getPostUploadFunction().accept(uploadResults);
-        }
-
-        return returnValue;
+        return uploadResults;
     }
 
 

--- a/src/main/java/com/cognite/client/queue/UploadQueue.java
+++ b/src/main/java/com/cognite/client/queue/UploadQueue.java
@@ -162,9 +162,15 @@ public abstract class UploadQueue<T> {
         String logPrefix = "put() - ";
         getQueue().put(element);
 
-        // Check the current no elements of the queue and trigger an upload if the fill rate is above threshold
-        // The upload will happen on a separate thread.
-        if (((float) getQueue().size() / ((float) getQueue().size() + (float) getQueue().remainingCapacity())) > QUEUE_FILL_RATE_THRESHOLD) {
+        /*
+        Check the current no elements of the queue and trigger an upload if the fill rate is above threshold, and
+        there are no upload requests in the background task queue. We have to check the background task queue so that
+        we prevent overprovisioning tasks.
+
+        The upload will happen on a separate thread.
+         */
+        if (((float) getQueue().size() / ((float) getQueue().size() + (float) getQueue().remainingCapacity())) > QUEUE_FILL_RATE_THRESHOLD
+                && getScheduledExecutor().getQueue().size() < 2) {
             LOG.debug(logPrefix + "Will trigger queue upload. Fill rate is above threshold. Queue capacity: {}, "
                     + "queue size: {}, remaining capacity: {}",
                     getQueue().size() + getQueue().remainingCapacity(),

--- a/src/main/java/com/cognite/client/queue/UploadQueue.java
+++ b/src/main/java/com/cognite/client/queue/UploadQueue.java
@@ -92,7 +92,7 @@ public abstract class UploadQueue<T> {
      * @param function The function to call in case of an exception during upload.
      * @return The {@link UploadQueue} with the function configured.
      */
-    public UploadQueue<T> withExceptionHandlerFunction(Consumer<? extends Throwable> function) {
+    public UploadQueue<T> withExceptionHandlerFunction(Consumer<Exception> function) {
         return toBuilder().setExceptionHandlerFunction(function).build();
     }
 

--- a/src/main/java/com/cognite/client/queue/UploadQueue.java
+++ b/src/main/java/com/cognite/client/queue/UploadQueue.java
@@ -222,6 +222,7 @@ public abstract class UploadQueue<T> {
         }
 
         recurringTask.cancel(false);
+        boolean returnValue = recurringTask.isDone();
         if (recurringTask.isDone()) {
             // cancellation of task was successful
             recurringTask = null;
@@ -233,7 +234,7 @@ public abstract class UploadQueue<T> {
                     recurringTask.isDone(),
                     recurringTask.isCancelled());
         }
-        return recurringTask.isDone();
+        return returnValue;
     }
 
     /*

--- a/src/main/java/com/cognite/client/queue/UploadQueue.java
+++ b/src/main/java/com/cognite/client/queue/UploadQueue.java
@@ -1,18 +1,14 @@
 package com.cognite.client.queue;
 
-import com.cognite.client.Request;
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Preconditions;
-import org.apache.commons.lang3.RandomStringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.time.Duration;
-import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.*;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
 /**
@@ -22,8 +18,6 @@ import java.util.function.Consumer;
 @AutoValue
 public abstract class UploadQueue<T> {
     protected final Logger LOG = LoggerFactory.getLogger(this.getClass());
-
-    protected static final Duration POLLING_INTERVAL = Duration.ofSeconds(1L);
 
     protected static final Duration MIN_MAX_UPLOAD_INTERVAL = Duration.ofSeconds(1L);
     protected static final Duration DEFAULT_MAX_UPLOAD_INTERVAL = Duration.ofSeconds(10L);
@@ -117,7 +111,8 @@ public abstract class UploadQueue<T> {
     /**
      * Sets the max upload interval.
      *
-     * If you have activated the The queue will be uploaded to
+     * When you activate the queue background thread via {@link #start()}, the queue will be uploaded to
+     * Cognite Data Fusion at least every upload interval (in addition to the upload triggered at 80% queue fill rate).
      *
      * The default max upload interval is 10 seconds.
      * @param interval The target max upload interval.

--- a/src/main/java/com/cognite/client/queue/UploadQueue.java
+++ b/src/main/java/com/cognite/client/queue/UploadQueue.java
@@ -1,0 +1,226 @@
+package com.cognite.client.queue;
+
+import com.cognite.client.Request;
+import com.cognite.client.stream.AbstractPublisher;
+import com.cognite.client.stream.AutoValue_Publisher;
+import com.cognite.client.stream.ListSource;
+import com.google.auto.value.AutoValue;
+import com.google.common.base.Preconditions;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+
+/**
+ *
+ * @param <T>
+ */
+@AutoValue
+public abstract class UploadQueue<T> {
+    protected final Logger LOG = LoggerFactory.getLogger(this.getClass());
+
+    protected static final Duration MIN_POLLING_INTERVAL = Duration.ofMillis(500L);
+    protected static final Duration DEFAULT_POLLING_INTERVAL = Duration.ofSeconds(5L);
+    protected static final Duration MAX_POLLING_INTERVAL = Duration.ofSeconds(60L);
+
+    // Internal state
+    protected AtomicBoolean abortStream = new AtomicBoolean(false);
+
+    private static <T> Builder<T> builder() {
+        return new AutoValue_UploadQueue.Builder<T>()
+                .setPollingInterval(DEFAULT_POLLING_INTERVAL)
+                .setPollingOffset(DEFAULT_POLLING_OFFSET)
+                .setRequest(Request.create())
+                ;
+    }
+
+    public static <T> UploadQueue<T> of(ListSource<T> listSource) {
+        return UploadQueue.<T>builder()
+                .setSource(listSource)
+                .build();
+    }
+
+    abstract Builder<T> toBuilder();
+
+    abstract ListSource<T> getSource();
+    abstract Request getRequest();
+    @Nullable
+    abstract Consumer<List<T>> getConsumer();
+
+    /**
+     * Add the consumer of the data stream.
+     *
+     * The consumer will be called for each batch of {@code T}. This is potentially a blocking operation,
+     * so you should take care to process the batch efficiently (or spin off processing to a separate thread).
+     *
+     * @param consumer The function to call for each batch of {@code T}.
+     * @return The {@link UploadQueue} with the consumer configured.
+     */
+    public UploadQueue<T> withConsumer(Consumer<List<T>> consumer) {
+        return toBuilder().setConsumer(consumer).build();
+    }
+
+    /**
+     * Sets the start time (i.e. the earliest possible created/changed time of the CDF Raw Row) of the data stream.
+     *
+     * The default start time is at Unix epoch. I.e. the publisher will read all existing rows (if any) in the raw table.
+     * @param startTime The start time instant
+     * @return The {@link UploadQueue} with the consumer configured.
+     */
+    public UploadQueue<T> withStartTime(Instant startTime) {
+        Preconditions.checkArgument(startTime.isAfter(MIN_START_TIME) && startTime.isBefore(MAX_END_TIME),
+                "Start time must be after Unix Epoch and before Instant.MAX.minus(1, ChronoUnit.YEARS).");
+        return toBuilder().setStartTime(startTime).build();
+    }
+
+    /**
+     * Sets the end time (i.e. the latest possible created/changed time of the CDF Raw Row) of the data stream.
+     *
+     * The default end time is {@code Instant.MAX}. I.e. the publisher will stream data indefinitely, or until
+     * aborted.
+     * @param endTime The end time instant
+     * @return The {@link UploadQueue} with the consumer configured.
+     */
+    public UploadQueue<T> withEndTime(Instant endTime) {
+        Preconditions.checkArgument(endTime.isAfter(MIN_START_TIME) && endTime.isBefore(MAX_END_TIME),
+                "End time must be after Unix Epoch and before Instant.MAX.minus(1, ChronoUnit.YEARS).");
+        return toBuilder().setEndTime(endTime).build();
+    }
+
+    /**
+     * Sets the polling interval to check for updates to the source raw table. The default polling interval is
+     * every 5 seconds. You can configure a more or less frequent interval, down to every 0.5 seconds.
+     *
+     * @param interval The interval to check the source raw table for updates.
+     * @return The {@link UploadQueue} with the consumer configured.
+     */
+    public UploadQueue<T> withPollingInterval(Duration interval) {
+        Preconditions.checkArgument(interval.compareTo(MIN_POLLING_INTERVAL) > 0
+                        && interval.compareTo(MAX_POLLING_INTERVAL) < 0,
+                String.format("Polling interval must be greater than %s and less than %s.",
+                        MIN_POLLING_INTERVAL,
+                        MAX_POLLING_INTERVAL));
+        return toBuilder().setPollingInterval(interval).build();
+    }
+
+    /**
+     * Sets the polling offset. The offset is a time window "buffer" subtracted from the current time when polling
+     * for data from CDF Raw. It is intended as a safeguard for clock differences between the client (running this
+     * publisher) and the CDF service.
+     *
+     * For example, if the polling offset is 2 seconds, then this publisher will look for data updates up to (and including)
+     * T-2 seconds. That is, data will be streamed with a 2 second fixed latency/delay.
+     *
+     * @param interval The interval to check the source raw table for updates.
+     * @return The {@link UploadQueue} with the consumer configured.
+     */
+    public UploadQueue<T> withPollingOffset(Duration interval) {
+        Preconditions.checkArgument(interval.compareTo(MIN_POLLING_OFFSET) > 0
+                        && interval.compareTo(MAX_POLLING_OFFSET) < 0,
+                String.format("Polling offset must be greater than %s and less than %s.",
+                        MIN_POLLING_OFFSET,
+                        MAX_POLLING_OFFSET));
+        return toBuilder().setPollingOffset(interval).build();
+    }
+
+    /**
+     * Sets a baseline {@link Request} to use when producing the steam of objects. The {@link Request} contains
+     * the set of filters that you want the (stream) objects to satisfy.
+     *
+     * @param request The baseline request specifying filters for the object stream.
+     * @return The {@link UploadQueue} with the consumer configured.
+     */
+    public UploadQueue<T> withRequest(Request request) {
+        Preconditions.checkArgument(0 == request.getRequestParameters().keySet()
+                .stream()
+                .filter(key -> !key.equals("filter"))
+                .count(),
+                "The request can only contain a filter node.");
+        return toBuilder().setRequest(request).build();
+    }
+
+
+    /**
+     * Start the main polling loop for reading rows from a raw table.
+     *
+     * @return {@code true} when the polling loop completes (at the specified end time). {@code false} if the
+     * job is aborted before the specified end time.
+     * @throws Exception
+     */
+    boolean run() throws Exception {
+        final String loggingPrefix = "streaming() [" + RandomStringUtils.randomAlphanumeric(4) + "] - ";
+        Preconditions.checkNotNull(getConsumer(),
+                loggingPrefix + "You must specify a Consumer via withConsumer(Consumer<List<RawRow>>)");
+        Preconditions.checkState(getStartTime().isBefore(getEndTime()),
+                String.format(loggingPrefix + "Start time must be before end time. Start time: %s. End time: %s",
+                        getStartTime(),
+                        getEndTime()));
+        LOG.info(loggingPrefix + "Setting up streaming read from {}. Time window start: {}. End: {}",
+                getSource().getClass().getSimpleName(),
+                getStartTime().toString(),
+                getEndTime().toString());
+        state = State.RUNNING;
+
+        // Set the time range for the first query
+        long startRange = getStartTime().toEpochMilli();
+        long endRange = Instant.now().minus(getPollingOffset()).toEpochMilli();
+
+        while (Instant.now().isBefore(getEndTime().plus(getPollingOffset())) && !abortStream.get()) {
+            endRange = Instant.now().minus(getPollingOffset()).toEpochMilli();
+            LOG.debug(loggingPrefix + "Enter polling loop with startRange: [{}] and endRange: [{}]",
+                    startRange,
+                    endRange);
+            if (startRange < endRange) {
+                Request query = getRequest()
+                        .withFilterParameter("lastUpdatedTime", Map.of(
+                                "min", startRange,
+                                "max", endRange))
+                        ;
+                LOG.debug(loggingPrefix + "Send request to read CDF: {}",
+                        query);
+
+                Iterator<List<T>> iterator = getSource().list(query);
+                while (iterator.hasNext() && !abortStream.get()) {
+                    List<T> batch = iterator.next();
+                    if (batch.size() > 0) {
+                        getConsumer().accept(batch);
+                    }
+                }
+            }
+
+            LOG.debug(loggingPrefix + "Finished polling loop with startRange: [{}] and endRange: [{}]. Sleeping for {}",
+                    startRange,
+                    endRange,
+                    getPollingInterval().toString());
+
+            startRange = endRange + 1; // endRange is inclusive in the request, so we must bump the next startRange
+
+            // Sleep for a polling interval
+            try {
+                Thread.sleep(getPollingInterval().toMillis());
+            } catch (Exception e) {
+                LOG.warn(loggingPrefix + "Exception when reading: " + e.toString());
+                abortStream.set(true);
+            }
+        }
+        state = State.STOPPED;
+        return !abortStream.get();
+    }
+
+    @AutoValue.Builder
+    abstract static class Builder<T> extends AbstractPublisher.Builder<Builder<T>> {
+        abstract Builder<T> setSource(ListSource<T> value);
+        abstract Builder<T> setConsumer(Consumer<List<T>> value);
+        abstract Builder<T> setRequest(Request value);
+
+        abstract UploadQueue<T> build();
+    }
+}

--- a/src/main/java/com/cognite/client/queue/UploadQueue.java
+++ b/src/main/java/com/cognite/client/queue/UploadQueue.java
@@ -16,6 +16,8 @@ import java.time.Instant;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
@@ -33,8 +35,13 @@ public abstract class UploadQueue<T> {
     protected static final Duration DEFAULT_MAX_UPLOAD_INTERVAL = Duration.ofSeconds(10L);
     protected static final Duration MAX_MAX_UPLOAD_INTERVAL = Duration.ofSeconds(60L);
 
+    protected static final int DEFAULT_QUEUE_SIZE = 20_000;
+
+    protected static final int DEFAULT_BATCH_SIZE = 8_000;
+
     // Internal state
     protected AtomicBoolean stopStream = new AtomicBoolean(false);
+    protected BlockingQueue<T> queue = new ArrayBlockingQueue<>()
 
     private static <T> Builder<T> builder() {
         return new AutoValue_UploadQueue.Builder<T>()
@@ -52,10 +59,12 @@ public abstract class UploadQueue<T> {
 
     abstract Builder<T> toBuilder();
 
-    abstract ListSource<T> getSource();
-    abstract Request getRequest();
+    abstract int getMaxQueueSize();
+    abstract int getBatchSize();
+    abstract Duration getMaxUploadInterval();
+    abstract BlockingQueue<T> getQueue();
     @Nullable
-    abstract Consumer<List<T>> getConsumer();
+    abstract Consumer<List<T>> getPostUploadFunction();
 
     /**
      * Add the consumer of the data stream.

--- a/src/main/java/com/cognite/client/queue/UploadQueue.java
+++ b/src/main/java/com/cognite/client/queue/UploadQueue.java
@@ -27,12 +27,14 @@ import java.util.function.Consumer;
 public abstract class UploadQueue<T> {
     protected final Logger LOG = LoggerFactory.getLogger(this.getClass());
 
-    protected static final Duration MIN_POLLING_INTERVAL = Duration.ofMillis(500L);
-    protected static final Duration DEFAULT_POLLING_INTERVAL = Duration.ofSeconds(5L);
-    protected static final Duration MAX_POLLING_INTERVAL = Duration.ofSeconds(60L);
+    protected static final Duration POLLING_INTERVAL = Duration.ofSeconds(1L);
+
+    protected static final Duration MIN_DEFAULT_MAX_UPLOAD_INTERVAL = Duration.ofSeconds(1L);
+    protected static final Duration DEFAULT_MAX_UPLOAD_INTERVAL = Duration.ofSeconds(10L);
+    protected static final Duration MAX_MAX_UPLOAD_INTERVAL = Duration.ofSeconds(60L);
 
     // Internal state
-    protected AtomicBoolean abortStream = new AtomicBoolean(false);
+    protected AtomicBoolean stopStream = new AtomicBoolean(false);
 
     private static <T> Builder<T> builder() {
         return new AutoValue_UploadQueue.Builder<T>()

--- a/src/main/java/com/cognite/client/queue/UploadQueue.java
+++ b/src/main/java/com/cognite/client/queue/UploadQueue.java
@@ -12,7 +12,7 @@ import java.util.concurrent.*;
 import java.util.function.Consumer;
 
 /**
- * The UploadQueue batches together items and uploads them together to Cognite Data Fusion (CDF), both to minimize
+ * The UploadQueue batches together items and uploads them to Cognite Data Fusion (CDF), both to minimize
  * the load on the API, and also to improve throughput.
  *
  * The queue is uploaded to CDF on three conditions:

--- a/src/main/java/com/cognite/client/queue/UploadQueue.java
+++ b/src/main/java/com/cognite/client/queue/UploadQueue.java
@@ -58,7 +58,7 @@ public abstract class UploadQueue<T> {
     abstract Consumer<List<T>> getPostUploadFunction();
 
     @Nullable
-    abstract Consumer<? extends Throwable> getExceptionHandlerFunction();
+    abstract Consumer<Exception> getExceptionHandlerFunction();
 
 
     @Nullable
@@ -200,7 +200,7 @@ public abstract class UploadQueue<T> {
         abstract Builder<T> setQueue(BlockingQueue<T> value);
         abstract Builder<T> setMaxUploadInterval(Duration value);
         abstract Builder<T> setPostUploadFunction(Consumer<List<T>> value);
-        abstract Builder<T> setExceptionHandlerFunction(Consumer<? extends Throwable> value);
+        abstract Builder<T> setExceptionHandlerFunction(Consumer<Exception> value);
         abstract Builder<T> setUpsertTarget(UpsertTarget<T> value);
 
         abstract ScheduledThreadPoolExecutor getScheduledExecutor();

--- a/src/main/java/com/cognite/client/queue/UploadQueue.java
+++ b/src/main/java/com/cognite/client/queue/UploadQueue.java
@@ -12,8 +12,27 @@ import java.util.concurrent.*;
 import java.util.function.Consumer;
 
 /**
+ * The UploadQueue batches together items and uploads them together to Cognite Data Fusion (CDF), both to minimize
+ * the load on the API, and also to improve throughput.
  *
- * @param <T>
+ * The queue is uploaded to CDF on three conditions:
+ * 1) When the queue is 80% full.
+ * 2) At a set interval (default is every 10 seconds).
+ * 3) When the {@link #upload()} method is called.
+ *
+ * The queue is always uploaded when 80% full. This happens on a background thread so your client can keep putting items
+ * on the queue while the upload runs in the background.
+ *
+ * The upload interval trigger must be explicitly enabled by calling the {@link #start()} method. This starts a
+ * background task that triggers a queue upload at a configurable interval. The default interval is every 10 seconds.
+ * The trigger interval works in combination with the fill rate interval--this is the recommended way to use the
+ * queue. When you are done using the queue, you should call {@link #stop()} for proper cleanup of background tasks
+ * and draining the queue.
+ *
+ * You can also trigger an upload manually by calling {@link #upload()}. This is a blocking function.
+ *
+ *
+ * @param <T> The CDF resource type to upload.
  */
 @AutoValue
 public abstract class UploadQueue<T> {

--- a/src/main/java/com/cognite/client/queue/UploadTarget.java
+++ b/src/main/java/com/cognite/client/queue/UploadTarget.java
@@ -1,0 +1,26 @@
+package com.cognite.client.queue;
+
+import java.util.List;
+
+/**
+ * An interface for API endpoints that supports uploading a resource type T.
+ *
+ * @param <T> The type of the resource to upsert to CDF.
+ * @param <R> The return type of the upload operation.
+ */
+public interface UploadTarget<T, R> {
+
+    /**
+     * Upserts a collection of objects to Cognite Data Fusion.
+     *
+     * <p>
+     * If it is a new object (based on {@code id / externalId}, then it will be created.
+     * <p>
+     * If the object already exists in Cognite Data Fusion, it will be updated. The update behavior
+     * is specified via the update mode in the {@link com.cognite.client.config.ClientConfig} settings.
+     *
+     * @param objects the objects to upsert to CDF
+     * @return a list of the confirmed upserted objects.
+     */
+    public List<R> upload(List<T> objects) throws Exception;
+}

--- a/src/main/java/com/cognite/client/queue/UpsertTarget.java
+++ b/src/main/java/com/cognite/client/queue/UpsertTarget.java
@@ -7,7 +7,7 @@ import java.util.List;
  *
  * @param <T> The type of the resource to upsert to CDF.
  */
-public interface UpsertTarget<T> {
+public interface UpsertTarget<T, R> {
 
     /**
      * Upserts a collection of objects to Cognite Data Fusion.
@@ -21,5 +21,5 @@ public interface UpsertTarget<T> {
      * @param objects the objects to upsert to CDF
      * @return a list of the confirmed upserted objects.
      */
-    public List<T> upsert(List<T> objects) throws Exception;
+    public List<R> upsert(List<T> objects) throws Exception;
 }

--- a/src/main/java/com/cognite/client/queue/UpsertTarget.java
+++ b/src/main/java/com/cognite/client/queue/UpsertTarget.java
@@ -1,0 +1,25 @@
+package com.cognite.client.queue;
+
+import java.util.List;
+
+/**
+ * An interface for API endpoints that supports upserting a resource type T.
+ *
+ * @param <T> The type of the resource to upsert to CDF.
+ */
+public interface UpsertTarget<T> {
+
+    /**
+     * Upserts a collection of objects to Cognite Data Fusion.
+     *
+     * <p>
+     * If it is a new object (based on {@code id / externalId}, then it will be created.
+     * <p>
+     * If the object already exists in Cognite Data Fusion, it will be updated. The update behavior
+     * is specified via the update mode in the {@link com.cognite.client.config.ClientConfig} settings.
+     *
+     * @param objects the objects to upsert to CDF
+     * @return a list of the confirmed upserted objects.
+     */
+    public List<T> upsert(List<T> objects) throws Exception;
+}

--- a/src/main/java/com/cognite/client/servicesV1/executor/RequestExecutor.java
+++ b/src/main/java/com/cognite/client/servicesV1/executor/RequestExecutor.java
@@ -33,10 +33,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
-import java.util.concurrent.ForkJoinPool;
-import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.*;
 
 /**
  * This class will execute an okhttp3 request on a separate thread and publish the result via a
@@ -64,9 +61,15 @@ public abstract class RequestExecutor {
             IOException.class
     );
 
-    private static final int DEFAULT_CPU_MULTIPLIER = 8;
-    private static final ForkJoinPool DEFAULT_POOL = new ForkJoinPool(Runtime.getRuntime().availableProcessors()
-            * DEFAULT_CPU_MULTIPLIER);
+    private static final int NO_WORKERS = 8;
+    private static final ThreadPoolExecutor DEFAULT_POOL = new ThreadPoolExecutor(NO_WORKERS, NO_WORKERS,
+            1000, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>());
+
+    //private static final ForkJoinPool DEFAULT_POOL = new ForkJoinPool();
+
+    static {
+        DEFAULT_POOL.allowCoreThreadTimeOut(true);
+    }
 
     protected final Logger LOG = LoggerFactory.getLogger(this.getClass());
 

--- a/src/test/java/com/cognite/client/EventsIntegrationTest.java
+++ b/src/test/java/com/cognite/client/EventsIntegrationTest.java
@@ -449,11 +449,16 @@ class EventsIntegrationTest {
         LOG.info(loggingPrefix + "----------------------------------------------------------------------");
 
         LOG.info(loggingPrefix + "Start uploading events.");
-        List<Event> upsertEventsList = DataGenerator.generateEvents(31800);
+        List<Event> upsertEventsList = DataGenerator.generateEvents(1800);
         UploadQueue<Event> uploadQueue = client.events().uploadQueue()
+                .withQueueSize(100)
                 .withPostUploadFunction(events -> LOG.info("postUploadFunction triggered. Uploaded {} items", events.size()))
                 .withExceptionHandlerFunction(exception -> LOG.warn("exceptionHandlerFunction triggered: {}", exception.getMessage()));
 
+        for (Event event : upsertEventsList) {
+            uploadQueue.put(event);
+        }
+        uploadQueue.upload();
 
         LOG.info(loggingPrefix + "Finished upserting events. Duration: {}",
                 Duration.between(startInstant, Instant.now()));

--- a/src/test/java/com/cognite/client/EventsIntegrationTest.java
+++ b/src/test/java/com/cognite/client/EventsIntegrationTest.java
@@ -449,7 +449,7 @@ class EventsIntegrationTest {
         LOG.info(loggingPrefix + "----------------------------------------------------------------------");
 
         LOG.info(loggingPrefix + "Start uploading events.");
-        List<Event> upsertEventsList = DataGenerator.generateEvents(1800);
+        List<Event> upsertEventsList = DataGenerator.generateEvents(1123);
         UploadQueue<Event> uploadQueue = client.events().uploadQueue()
                 .withQueueSize(100)
                 .withPostUploadFunction(events -> LOG.info("postUploadFunction triggered. Uploaded {} items", events.size()))

--- a/src/test/java/com/cognite/client/EventsIntegrationTest.java
+++ b/src/test/java/com/cognite/client/EventsIntegrationTest.java
@@ -447,7 +447,7 @@ class EventsIntegrationTest {
 
         LOG.info(loggingPrefix + "Start uploading events.");
         List<Event> upsertEventsList = DataGenerator.generateEvents(1123);
-        UploadQueue<Event> uploadQueue = client.events().uploadQueue()
+        UploadQueue<Event, Event> uploadQueue = client.events().uploadQueue()
                 .withQueueSize(100)
                 .withMaxUploadInterval(Duration.ofSeconds(1))
                 .withPostUploadFunction(events -> LOG.info("postUploadFunction triggered. Uploaded {} items", events.size()))

--- a/src/test/java/com/cognite/client/TimeseriesIntegrationTest.java
+++ b/src/test/java/com/cognite/client/TimeseriesIntegrationTest.java
@@ -430,7 +430,7 @@ class TimeseriesIntegrationTest {
                 upsertTimeseriesList.stream()
                         .map(header -> header.getExternalId())
                         .collect(Collectors.toList()));
-        UploadQueue<TimeseriesPointPost> uploadQueue = client.timeseries().dataPoints().uploadQueue()
+        UploadQueue<TimeseriesPointPost, TimeseriesPointPost> uploadQueue = client.timeseries().dataPoints().uploadQueue()
                 .withMaxUploadInterval(Duration.ofSeconds(1))
                 .withPostUploadFunction(events -> LOG.info("postUploadFunction triggered. Uploaded {} items", events.size()))
                 .withExceptionHandlerFunction(exception -> LOG.warn("exceptionHandlerFunction triggered: {}", exception.getMessage()));

--- a/src/test/java/com/cognite/client/TimeseriesIntegrationTest.java
+++ b/src/test/java/com/cognite/client/TimeseriesIntegrationTest.java
@@ -1,9 +1,11 @@
 package com.cognite.client;
 
+import com.amazonaws.services.s3.transfer.Upload;
 import com.cognite.client.config.ClientConfig;
 import com.cognite.client.config.TokenUrl;
 import com.cognite.client.config.UpsertMode;
 import com.cognite.client.dto.*;
+import com.cognite.client.queue.UploadQueue;
 import com.cognite.client.util.DataGenerator;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -43,42 +45,37 @@ class TimeseriesIntegrationTest {
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",
                 Duration.between(startInstant, Instant.now()));
 
-        try {
-            LOG.info(loggingPrefix + "Start upserting timeseries.");
-            List<TimeseriesMetadata> upsertTimeseriesList = DataGenerator.generateTsHeaderObjects(9800);
-            client.timeseries().upsert(upsertTimeseriesList);
-            LOG.info(loggingPrefix + "Finished upserting timeseries. Duration: {}",
-                    Duration.between(startInstant, Instant.now()));
+        LOG.info(loggingPrefix + "Start upserting timeseries.");
+        List<TimeseriesMetadata> upsertTimeseriesList = DataGenerator.generateTsHeaderObjects(9800);
+        client.timeseries().upsert(upsertTimeseriesList);
+        LOG.info(loggingPrefix + "Finished upserting timeseries. Duration: {}",
+                Duration.between(startInstant, Instant.now()));
 
-            Thread.sleep(20000); // wait for eventual consistency
+        Thread.sleep(20000); // wait for eventual consistency
 
-            LOG.info(loggingPrefix + "Start reading timeseries.");
-            List<TimeseriesMetadata> listTimeseriesResults = new ArrayList<>();
-            client.timeseries()
-                    .list(Request.create()
-                            .withFilterMetadataParameter("source", DataGenerator.sourceValue))
-                    .forEachRemaining(timeseries -> listTimeseriesResults.addAll(timeseries));
-            LOG.info(loggingPrefix + "Finished reading timeseries. Duration: {}",
-                    Duration.between(startInstant, Instant.now()));
+        LOG.info(loggingPrefix + "Start reading timeseries.");
+        List<TimeseriesMetadata> listTimeseriesResults = new ArrayList<>();
+        client.timeseries()
+                .list(Request.create()
+                        .withFilterMetadataParameter("source", DataGenerator.sourceValue))
+                .forEachRemaining(timeseries -> listTimeseriesResults.addAll(timeseries));
+        LOG.info(loggingPrefix + "Finished reading timeseries. Duration: {}",
+                Duration.between(startInstant, Instant.now()));
 
-            LOG.info(loggingPrefix + "Start deleting timeseries.");
-            List<Item> deleteItemsInput = new ArrayList<>();
-            listTimeseriesResults.stream()
-                    .map(timeseries -> Item.newBuilder()
-                            .setExternalId(timeseries.getExternalId())
-                            .build())
-                    .forEach(item -> deleteItemsInput.add(item));
+        LOG.info(loggingPrefix + "Start deleting timeseries.");
+        List<Item> deleteItemsInput = new ArrayList<>();
+        listTimeseriesResults.stream()
+                .map(timeseries -> Item.newBuilder()
+                        .setExternalId(timeseries.getExternalId())
+                        .build())
+                .forEach(item -> deleteItemsInput.add(item));
 
-            List<Item> deleteItemsResults = client.timeseries().delete(deleteItemsInput);
-            LOG.info(loggingPrefix + "Finished deleting timeseries. Duration: {}",
-                    Duration.between(startInstant, Instant.now()));
+        List<Item> deleteItemsResults = client.timeseries().delete(deleteItemsInput);
+        LOG.info(loggingPrefix + "Finished deleting timeseries. Duration: {}",
+                Duration.between(startInstant, Instant.now()));
 
-            assertEquals(upsertTimeseriesList.size(), listTimeseriesResults.size());
-            assertEquals(deleteItemsInput.size(), deleteItemsResults.size());
-        } catch (Exception e) {
-            LOG.error(e.toString());
-            throw new RuntimeException(e);
-        }
+        assertEquals(upsertTimeseriesList.size(), listTimeseriesResults.size());
+        assertEquals(deleteItemsInput.size(), deleteItemsResults.size());
     }
 
     @Test
@@ -106,72 +103,67 @@ class TimeseriesIntegrationTest {
                 Duration.between(startInstant, Instant.now()));
         LOG.info(loggingPrefix + "----------------------------------------------------------------------");
 
-        try {
-            LOG.info(loggingPrefix + "Start upserting timeseries.");
-            List<TimeseriesMetadata> upsertTimeseriesList = DataGenerator.generateTsHeaderObjects(noTsHeaders);
-            client.timeseries().upsert(upsertTimeseriesList);
-            LOG.info(loggingPrefix + "Finished upserting timeseries. Duration: {}",
-                    Duration.between(startInstant, Instant.now()));
-            LOG.info(loggingPrefix + "----------------------------------------------------------------------");
+        LOG.info(loggingPrefix + "Start upserting timeseries.");
+        List<TimeseriesMetadata> upsertTimeseriesList = DataGenerator.generateTsHeaderObjects(noTsHeaders);
+        client.timeseries().upsert(upsertTimeseriesList);
+        LOG.info(loggingPrefix + "Finished upserting timeseries. Duration: {}",
+                Duration.between(startInstant, Instant.now()));
+        LOG.info(loggingPrefix + "----------------------------------------------------------------------");
 
-            Thread.sleep(5000); // wait for eventual consistency
-            LOG.info(loggingPrefix + "Start upserting data points.");
-            List<TimeseriesPointPost> upsertDataPointsList = DataGenerator.generateTsDatapointsObjects(
-                    noTsPoints,
-                    tsPointsFrequency,
-                    upsertTimeseriesList.stream()
-                            .map(header -> header.getExternalId())
-                            .collect(Collectors.toList()));
-            client.timeseries().dataPoints().upsert(upsertDataPointsList);
-            LOG.info(loggingPrefix + "Finished upserting data points. Duration: {}",
-                    Duration.between(startInstant, Instant.now()));
-            LOG.info(loggingPrefix + "----------------------------------------------------------------------");
+        Thread.sleep(5000); // wait for eventual consistency
+        LOG.info(loggingPrefix + "Start upserting data points.");
+        List<TimeseriesPointPost> upsertDataPointsList = DataGenerator.generateTsDatapointsObjects(
+                noTsPoints,
+                tsPointsFrequency,
+                upsertTimeseriesList.stream()
+                        .map(header -> header.getExternalId())
+                        .collect(Collectors.toList()));
+        client.timeseries().dataPoints().upsert(upsertDataPointsList);
+        LOG.info(loggingPrefix + "Finished upserting data points. Duration: {}",
+                Duration.between(startInstant, Instant.now()));
+        LOG.info(loggingPrefix + "----------------------------------------------------------------------");
 
-            Thread.sleep(5000); // wait for eventual consistency
+        Thread.sleep(5000); // wait for eventual consistency
 
-            LOG.info(loggingPrefix + "Start reading timeseries.");
-            List<TimeseriesMetadata> listTimeseriesResults = new ArrayList<>();
-            client.timeseries()
-                    .list(Request.create()
-                            .withFilterMetadataParameter("source", DataGenerator.sourceValue))
-                    .forEachRemaining(timeseries -> listTimeseriesResults.addAll(timeseries));
-            LOG.info(loggingPrefix + "Finished reading timeseries. Duration: {}",
-                    Duration.between(startInstant, Instant.now()));
-            LOG.info(loggingPrefix + "----------------------------------------------------------------------");
+        LOG.info(loggingPrefix + "Start reading timeseries.");
+        List<TimeseriesMetadata> listTimeseriesResults = new ArrayList<>();
+        client.timeseries()
+                .list(Request.create()
+                        .withFilterMetadataParameter("source", DataGenerator.sourceValue))
+                .forEachRemaining(timeseries -> listTimeseriesResults.addAll(timeseries));
+        LOG.info(loggingPrefix + "Finished reading timeseries. Duration: {}",
+                Duration.between(startInstant, Instant.now()));
+        LOG.info(loggingPrefix + "----------------------------------------------------------------------");
 
-            LOG.info(loggingPrefix + "Start reading data points.");
-            List<Item> listDataPointsItems = upsertTimeseriesList.stream()
-                    .map(header -> Item.newBuilder()
-                            .setExternalId(header.getExternalId())
-                            .build())
-                    .collect(Collectors.toList());
-            List<TimeseriesPoint> readDataPointsResults = new ArrayList<>();
-            client.timeseries().dataPoints().retrieveComplete(listDataPointsItems)
-                    .forEachRemaining(timeseries -> readDataPointsResults.addAll(timeseries));
-            LOG.info(loggingPrefix + "Finished reading data points. Duration: {}",
-                    Duration.between(startInstant, Instant.now()));
-            LOG.info(loggingPrefix + "----------------------------------------------------------------------");
+        LOG.info(loggingPrefix + "Start reading data points.");
+        List<Item> listDataPointsItems = upsertTimeseriesList.stream()
+                .map(header -> Item.newBuilder()
+                        .setExternalId(header.getExternalId())
+                        .build())
+                .collect(Collectors.toList());
+        List<TimeseriesPoint> readDataPointsResults = new ArrayList<>();
+        client.timeseries().dataPoints().retrieveComplete(listDataPointsItems)
+                .forEachRemaining(timeseries -> readDataPointsResults.addAll(timeseries));
+        LOG.info(loggingPrefix + "Finished reading data points. Duration: {}",
+                Duration.between(startInstant, Instant.now()));
+        LOG.info(loggingPrefix + "----------------------------------------------------------------------");
 
-            LOG.info(loggingPrefix + "Start deleting timeseries.");
-            List<Item> deleteItemsInput = new ArrayList<>();
-            listTimeseriesResults.stream()
-                    .map(timeseries -> Item.newBuilder()
-                            .setExternalId(timeseries.getExternalId())
-                            .build())
-                    .forEach(item -> deleteItemsInput.add(item));
+        LOG.info(loggingPrefix + "Start deleting timeseries.");
+        List<Item> deleteItemsInput = new ArrayList<>();
+        listTimeseriesResults.stream()
+                .map(timeseries -> Item.newBuilder()
+                        .setExternalId(timeseries.getExternalId())
+                        .build())
+                .forEach(item -> deleteItemsInput.add(item));
 
-            List<Item> deleteItemsResults = client.timeseries().delete(deleteItemsInput);
-            LOG.info(loggingPrefix + "Finished deleting timeseries. Duration: {}",
-                    Duration.between(startInstant, Instant.now()));
-            LOG.info(loggingPrefix + "----------------------------------------------------------------------");
+        List<Item> deleteItemsResults = client.timeseries().delete(deleteItemsInput);
+        LOG.info(loggingPrefix + "Finished deleting timeseries. Duration: {}",
+                Duration.between(startInstant, Instant.now()));
+        LOG.info(loggingPrefix + "----------------------------------------------------------------------");
 
-            assertEquals(upsertDataPointsList.size(), readDataPointsResults.size());
-            assertEquals(upsertTimeseriesList.size(), listTimeseriesResults.size());
-            assertEquals(deleteItemsInput.size(), deleteItemsResults.size());
-        } catch (Exception e) {
-            LOG.error(e.toString());
-            throw new RuntimeException(e);
-        }
+        assertEquals(upsertDataPointsList.size(), readDataPointsResults.size());
+        assertEquals(upsertTimeseriesList.size(), listTimeseriesResults.size());
+        assertEquals(deleteItemsInput.size(), deleteItemsResults.size());
     }
 
     @Test
@@ -186,100 +178,94 @@ class TimeseriesIntegrationTest {
                     TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
                     .withProject(TestConfigProvider.getProject())
                     .withBaseUrl(TestConfigProvider.getHost())
-                //.withClientConfig(config)
                 ;
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",
                 Duration.between(startInstant, Instant.now()));
 
-        try {
-            LOG.info(loggingPrefix + "Start upserting timeseries.");
-            List<TimeseriesMetadata> upsertTimeseriesList = DataGenerator.generateTsHeaderObjects(123);
-            List<TimeseriesMetadata> upsertedTimeseries = client.timeseries().upsert(upsertTimeseriesList);
-            LOG.info(loggingPrefix + "Finished upserting timeseries. Duration: {}",
-                    Duration.between(startInstant, Instant.now()));
+        LOG.info(loggingPrefix + "Start upserting timeseries.");
+        List<TimeseriesMetadata> upsertTimeseriesList = DataGenerator.generateTsHeaderObjects(123);
+        List<TimeseriesMetadata> upsertedTimeseries = client.timeseries().upsert(upsertTimeseriesList);
+        LOG.info(loggingPrefix + "Finished upserting timeseries. Duration: {}",
+                Duration.between(startInstant, Instant.now()));
 
-            Thread.sleep(3000); // wait for eventual consistency
+        Thread.sleep(3000); // wait for eventual consistency
 
-            LOG.info(loggingPrefix + "Start updating timeseries.");
-            List<TimeseriesMetadata> editedTimeseriesInput = upsertedTimeseries.stream()
-                    .map(timeseries -> timeseries.toBuilder()
-                            .setDescription("new-value")
-                            .clearMetadata()
-                            .putMetadata("new-key", "new-value")
-                            .build())
-                    .collect(Collectors.toList());
+        LOG.info(loggingPrefix + "Start updating timeseries.");
+        List<TimeseriesMetadata> editedTimeseriesInput = upsertedTimeseries.stream()
+                .map(timeseries -> timeseries.toBuilder()
+                        .setDescription("new-value")
+                        .clearMetadata()
+                        .putMetadata("new-key", "new-value")
+                        .build())
+                .collect(Collectors.toList());
 
-            List<TimeseriesMetadata> timeseriesUpdateResults = client.timeseries().upsert(editedTimeseriesInput);
-            LOG.info(loggingPrefix + "Finished updating timeseries. Duration: {}",
-                    Duration.between(startInstant, Instant.now()));
+        List<TimeseriesMetadata> timeseriesUpdateResults = client.timeseries().upsert(editedTimeseriesInput);
+        LOG.info(loggingPrefix + "Finished updating timeseries. Duration: {}",
+                Duration.between(startInstant, Instant.now()));
 
-            LOG.info(loggingPrefix + "Start update replace timeseries.");
-            client = client
-                    .withClientConfig(ClientConfig.create()
-                            .withUpsertMode(UpsertMode.REPLACE));
+        LOG.info(loggingPrefix + "Start update replace timeseries.");
+        client = client
+                .withClientConfig(ClientConfig.create()
+                        .withUpsertMode(UpsertMode.REPLACE));
 
-            List<TimeseriesMetadata> timeseriesReplaceResults = client.timeseries().upsert(editedTimeseriesInput);
-            LOG.info(loggingPrefix + "Finished update replace timeseries. Duration: {}",
-                    Duration.between(startInstant, Instant.now()));
+        List<TimeseriesMetadata> timeseriesReplaceResults = client.timeseries().upsert(editedTimeseriesInput);
+        LOG.info(loggingPrefix + "Finished update replace timeseries. Duration: {}",
+                Duration.between(startInstant, Instant.now()));
 
-            Thread.sleep(3000); // wait for eventual consistency
+        Thread.sleep(3000); // wait for eventual consistency
 
-            LOG.info(loggingPrefix + "Start reading timeseries.");
-            List<TimeseriesMetadata> listTimeseriesResults = new ArrayList<>();
-            client.timeseries()
-                    .list(Request.create()
-                            .withFilterMetadataParameter("new-key", "new-value"))
-                    .forEachRemaining(timeseries -> listTimeseriesResults.addAll(timeseries));
-            LOG.info(loggingPrefix + "Finished reading timeseries. Duration: {}",
-                    Duration.between(startInstant, Instant.now()));
+        LOG.info(loggingPrefix + "Start reading timeseries.");
+        List<TimeseriesMetadata> listTimeseriesResults = new ArrayList<>();
+        client.timeseries()
+                .list(Request.create()
+                        .withFilterMetadataParameter("new-key", "new-value"))
+                .forEachRemaining(timeseries -> listTimeseriesResults.addAll(timeseries));
+        LOG.info(loggingPrefix + "Finished reading timeseries. Duration: {}",
+                Duration.between(startInstant, Instant.now()));
 
-            LOG.info(loggingPrefix + "Start deleting timeseries.");
-            List<Item> deleteItemsInput = new ArrayList<>();
-            listTimeseriesResults.stream()
-                    .map(event -> Item.newBuilder()
-                            .setExternalId(event.getExternalId())
-                            .build())
-                    .forEach(item -> deleteItemsInput.add(item));
+        LOG.info(loggingPrefix + "Start deleting timeseries.");
+        List<Item> deleteItemsInput = new ArrayList<>();
+        listTimeseriesResults.stream()
+                .map(event -> Item.newBuilder()
+                        .setExternalId(event.getExternalId())
+                        .build())
+                .forEach(item -> deleteItemsInput.add(item));
 
-            List<Item> deleteItemsResults = client.timeseries().delete(deleteItemsInput);
-            LOG.info(loggingPrefix + "Finished deleting timeseries. Duration: {}",
-                    Duration.between(startInstant, Instant.now()));
+        List<Item> deleteItemsResults = client.timeseries().delete(deleteItemsInput);
+        LOG.info(loggingPrefix + "Finished deleting timeseries. Duration: {}",
+                Duration.between(startInstant, Instant.now()));
 
-            BooleanSupplier updateCondition = () -> {
-                for (TimeseriesMetadata timeseries : timeseriesUpdateResults)  {
-                    if (timeseries.getDescription().equals("new-value")
-                            && timeseries.containsMetadata("new-key")
-                            && timeseries.containsMetadata(DataGenerator.sourceKey)) {
-                        // all good
-                    } else {
-                        return false;
-                    }
+        BooleanSupplier updateCondition = () -> {
+            for (TimeseriesMetadata timeseries : timeseriesUpdateResults)  {
+                if (timeseries.getDescription().equals("new-value")
+                        && timeseries.containsMetadata("new-key")
+                        && timeseries.containsMetadata(DataGenerator.sourceKey)) {
+                    // all good
+                } else {
+                    return false;
                 }
-                return true;
-            };
+            }
+            return true;
+        };
 
-            BooleanSupplier replaceCondition = () -> {
-                for (TimeseriesMetadata timeseries : timeseriesReplaceResults)  {
-                    if (timeseries.getDescription().equals("new-value")
-                            && timeseries.containsMetadata("new-key")
-                            && !timeseries.containsMetadata(DataGenerator.sourceKey)) {
-                        // all good
-                    } else {
-                        return false;
-                    }
+        BooleanSupplier replaceCondition = () -> {
+            for (TimeseriesMetadata timeseries : timeseriesReplaceResults)  {
+                if (timeseries.getDescription().equals("new-value")
+                        && timeseries.containsMetadata("new-key")
+                        && !timeseries.containsMetadata(DataGenerator.sourceKey)) {
+                    // all good
+                } else {
+                    return false;
                 }
-                return true;
-            };
+            }
+            return true;
+        };
 
-            assertTrue(updateCondition, "Timeseries update not correct");
-            assertTrue(replaceCondition, "Timeseries replace not correct");
+        assertTrue(updateCondition, "Timeseries update not correct");
+        assertTrue(replaceCondition, "Timeseries replace not correct");
 
-            assertEquals(upsertTimeseriesList.size(), listTimeseriesResults.size());
-            assertEquals(deleteItemsInput.size(), deleteItemsResults.size());
-        } catch (Exception e) {
-            LOG.error(e.toString());
-            throw new RuntimeException(e);
-        }
+        assertEquals(upsertTimeseriesList.size(), listTimeseriesResults.size());
+        assertEquals(deleteItemsInput.size(), deleteItemsResults.size());
     }
 
     @Test
@@ -299,55 +285,50 @@ class TimeseriesIntegrationTest {
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",
                 Duration.between(startInstant, Instant.now()));
 
-        try {
-            LOG.info(loggingPrefix + "Start upserting timeseries.");
-            List<TimeseriesMetadata> upsertTimeseriesList = DataGenerator.generateTsHeaderObjects(16800);
-            client.timeseries().upsert(upsertTimeseriesList);
-            LOG.info(loggingPrefix + "Finished upserting timeseries. Duration: {}",
-                    Duration.between(startInstant, Instant.now()));
+        LOG.info(loggingPrefix + "Start upserting timeseries.");
+        List<TimeseriesMetadata> upsertTimeseriesList = DataGenerator.generateTsHeaderObjects(16800);
+        client.timeseries().upsert(upsertTimeseriesList);
+        LOG.info(loggingPrefix + "Finished upserting timeseries. Duration: {}",
+                Duration.between(startInstant, Instant.now()));
 
-            Thread.sleep(15000); // wait for eventual consistency
+        Thread.sleep(15000); // wait for eventual consistency
 
-            LOG.info(loggingPrefix + "Start listing timeseries.");
-            List<TimeseriesMetadata> listTimeseriesResults = new ArrayList<>();
-            client.timeseries()
-                    .list(Request.create()
-                            .withFilterMetadataParameter("source", DataGenerator.sourceValue))
-                    .forEachRemaining(timeseries -> listTimeseriesResults.addAll(timeseries));
-            LOG.info(loggingPrefix + "Finished listing timeseries. Duration: {}",
-                    Duration.between(startInstant, Instant.now()));
+        LOG.info(loggingPrefix + "Start listing timeseries.");
+        List<TimeseriesMetadata> listTimeseriesResults = new ArrayList<>();
+        client.timeseries()
+                .list(Request.create()
+                        .withFilterMetadataParameter("source", DataGenerator.sourceValue))
+                .forEachRemaining(timeseries -> listTimeseriesResults.addAll(timeseries));
+        LOG.info(loggingPrefix + "Finished listing timeseries. Duration: {}",
+                Duration.between(startInstant, Instant.now()));
 
-            LOG.info(loggingPrefix + "Start retrieving timeseries.");
-            List<Item> timeseriesItems = new ArrayList<>();
-            listTimeseriesResults.stream()
-                    .map(timeseries -> Item.newBuilder()
-                            .setExternalId(timeseries.getExternalId())
-                            .build())
-                    .forEach(item -> timeseriesItems.add(item));
+        LOG.info(loggingPrefix + "Start retrieving timeseries.");
+        List<Item> timeseriesItems = new ArrayList<>();
+        listTimeseriesResults.stream()
+                .map(timeseries -> Item.newBuilder()
+                        .setExternalId(timeseries.getExternalId())
+                        .build())
+                .forEach(item -> timeseriesItems.add(item));
 
-            List<TimeseriesMetadata> retrievedTimeseries = client.timeseries().retrieve(timeseriesItems);
-            LOG.info(loggingPrefix + "Finished retrieving timeseries. Duration: {}",
-                    Duration.between(startInstant, Instant.now()));
+        List<TimeseriesMetadata> retrievedTimeseries = client.timeseries().retrieve(timeseriesItems);
+        LOG.info(loggingPrefix + "Finished retrieving timeseries. Duration: {}",
+                Duration.between(startInstant, Instant.now()));
 
-            LOG.info(loggingPrefix + "Start deleting timeseries.");
-            List<Item> deleteItemsInput = new ArrayList<>();
-            retrievedTimeseries.stream()
-                    .map(timeseries -> Item.newBuilder()
-                            .setExternalId(timeseries.getExternalId())
-                            .build())
-                    .forEach(item -> deleteItemsInput.add(item));
+        LOG.info(loggingPrefix + "Start deleting timeseries.");
+        List<Item> deleteItemsInput = new ArrayList<>();
+        retrievedTimeseries.stream()
+                .map(timeseries -> Item.newBuilder()
+                        .setExternalId(timeseries.getExternalId())
+                        .build())
+                .forEach(item -> deleteItemsInput.add(item));
 
-            List<Item> deleteItemsResults = client.timeseries().delete(deleteItemsInput);
-            LOG.info(loggingPrefix + "Finished deleting timeseries. Duration: {}",
-                    Duration.between(startInstant, Instant.now()));
+        List<Item> deleteItemsResults = client.timeseries().delete(deleteItemsInput);
+        LOG.info(loggingPrefix + "Finished deleting timeseries. Duration: {}",
+                Duration.between(startInstant, Instant.now()));
 
-            assertEquals(upsertTimeseriesList.size(), listTimeseriesResults.size());
-            assertEquals(deleteItemsInput.size(), deleteItemsResults.size());
-            assertEquals(timeseriesItems.size(), retrievedTimeseries.size());
-        } catch (Exception e) {
-            LOG.error(e.toString());
-            throw new RuntimeException(e);
-        }
+        assertEquals(upsertTimeseriesList.size(), listTimeseriesResults.size());
+        assertEquals(deleteItemsInput.size(), deleteItemsResults.size());
+        assertEquals(timeseriesItems.size(), retrievedTimeseries.size());
     }
 
     @Test
@@ -368,50 +349,141 @@ class TimeseriesIntegrationTest {
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",
                 Duration.between(startInstant, Instant.now()));
 
-        try {
-            LOG.info(loggingPrefix + "Start upserting timeseries.");
-            List<TimeseriesMetadata> upsertTimeseriesList = DataGenerator.generateTsHeaderObjects(noItems);
-            client.timeseries().upsert(upsertTimeseriesList);
-            LOG.info(loggingPrefix + "Finished upserting timeseries. Duration: {}",
-                    Duration.between(startInstant, Instant.now()));
+        LOG.info(loggingPrefix + "Start upserting timeseries.");
+        List<TimeseriesMetadata> upsertTimeseriesList = DataGenerator.generateTsHeaderObjects(noItems);
+        client.timeseries().upsert(upsertTimeseriesList);
+        LOG.info(loggingPrefix + "Finished upserting timeseries. Duration: {}",
+                Duration.between(startInstant, Instant.now()));
 
-            Thread.sleep(10000); // wait for eventual consistency
+        Thread.sleep(10000); // wait for eventual consistency
 
-            LOG.info(loggingPrefix + "Start aggregating timeseries.");
-            Aggregate aggregateResult = client.timeseries()
-                    .aggregate(Request.create()
-                            .withFilterMetadataParameter("source", DataGenerator.sourceValue));
-            LOG.info(loggingPrefix + "Aggregate results: {}", aggregateResult);
-            LOG.info(loggingPrefix + "Finished aggregating timeseries. Duration: {}",
-                    Duration.between(startInstant, Instant.now()));
+        LOG.info(loggingPrefix + "Start aggregating timeseries.");
+        Aggregate aggregateResult = client.timeseries()
+                .aggregate(Request.create()
+                        .withFilterMetadataParameter("source", DataGenerator.sourceValue));
+        LOG.info(loggingPrefix + "Aggregate results: {}", aggregateResult);
+        LOG.info(loggingPrefix + "Finished aggregating timeseries. Duration: {}",
+                Duration.between(startInstant, Instant.now()));
 
-            LOG.info(loggingPrefix + "Start reading timeseries.");
-            List<TimeseriesMetadata> listTimeseriesResults = new ArrayList<>();
-            client.timeseries()
-                    .list(Request.create()
-                            .withFilterMetadataParameter("source", DataGenerator.sourceValue))
-                    .forEachRemaining(timeseries -> listTimeseriesResults.addAll(timeseries));
-            LOG.info(loggingPrefix + "Finished reading timeseries. Duration: {}",
-                    Duration.between(startInstant, Instant.now()));
+        LOG.info(loggingPrefix + "Start reading timeseries.");
+        List<TimeseriesMetadata> listTimeseriesResults = new ArrayList<>();
+        client.timeseries()
+                .list(Request.create()
+                        .withFilterMetadataParameter("source", DataGenerator.sourceValue))
+                .forEachRemaining(timeseries -> listTimeseriesResults.addAll(timeseries));
+        LOG.info(loggingPrefix + "Finished reading timeseries. Duration: {}",
+                Duration.between(startInstant, Instant.now()));
 
-            LOG.info(loggingPrefix + "Start deleting timeseries.");
-            List<Item> deleteItemsInput = new ArrayList<>();
-            listTimeseriesResults.stream()
-                    .map(timeseries -> Item.newBuilder()
-                            .setExternalId(timeseries.getExternalId())
-                            .build())
-                    .forEach(item -> deleteItemsInput.add(item));
+        LOG.info(loggingPrefix + "Start deleting timeseries.");
+        List<Item> deleteItemsInput = new ArrayList<>();
+        listTimeseriesResults.stream()
+                .map(timeseries -> Item.newBuilder()
+                        .setExternalId(timeseries.getExternalId())
+                        .build())
+                .forEach(item -> deleteItemsInput.add(item));
 
-            List<Item> deleteItemsResults = client.timeseries().delete(deleteItemsInput);
-            LOG.info(loggingPrefix + "Finished deleting timeseries. Duration: {}",
-                    Duration.between(startInstant, Instant.now()));
+        List<Item> deleteItemsResults = client.timeseries().delete(deleteItemsInput);
+        LOG.info(loggingPrefix + "Finished deleting timeseries. Duration: {}",
+                Duration.between(startInstant, Instant.now()));
 
-            assertEquals(upsertTimeseriesList.size(), listTimeseriesResults.size());
-            assertEquals(deleteItemsInput.size(), deleteItemsResults.size());
-        } catch (Exception e) {
-            LOG.error(e.toString());
-            throw new RuntimeException(e);
-        }
+        assertEquals(upsertTimeseriesList.size(), listTimeseriesResults.size());
+        assertEquals(deleteItemsInput.size(), deleteItemsResults.size());
     }
 
+    @Test
+    @Tag("remoteCDP")
+    void writeUploadQueueAndDeleteTimeseriesDataPoints() throws Exception {
+        Instant startInstant = Instant.now();
+        final int noTsHeaders = 5;
+        final int noTsPoints = 51789;
+        final double tsPointsFrequency = 1d;
+        ClientConfig config = ClientConfig.create()
+                .withNoWorkers(4)
+                .withNoListPartitions(4);
+        String loggingPrefix = "UnitTest - writeUploadQueueAndDeleteTimeseriesDataPoints() -";
+        LOG.info(loggingPrefix + "----------------------------------------------------------------------");
+        LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
+        CogniteClient client = CogniteClient.ofClientCredentials(
+                        TestConfigProvider.getClientId(),
+                        TestConfigProvider.getClientSecret(),
+                        TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
+                .withProject(TestConfigProvider.getProject())
+                .withBaseUrl(TestConfigProvider.getHost())
+                //.withClientConfig(config)
+                ;
+        LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",
+                Duration.between(startInstant, Instant.now()));
+        LOG.info(loggingPrefix + "----------------------------------------------------------------------");
+
+        LOG.info(loggingPrefix + "Start upserting timeseries.");
+        List<TimeseriesMetadata> upsertTimeseriesList = DataGenerator.generateTsHeaderObjects(noTsHeaders);
+        client.timeseries().upsert(upsertTimeseriesList);
+        LOG.info(loggingPrefix + "Finished upserting timeseries. Duration: {}",
+                Duration.between(startInstant, Instant.now()));
+        LOG.info(loggingPrefix + "----------------------------------------------------------------------");
+
+        Thread.sleep(5000); // wait for eventual consistency
+        LOG.info(loggingPrefix + "Start upserting data points.");
+        List<TimeseriesPointPost> upsertDataPointsList = DataGenerator.generateTsDatapointsObjects(
+                noTsPoints,
+                tsPointsFrequency,
+                upsertTimeseriesList.stream()
+                        .map(header -> header.getExternalId())
+                        .collect(Collectors.toList()));
+        UploadQueue<TimeseriesPointPost> uploadQueue = client.timeseries().dataPoints().uploadQueue()
+                .withMaxUploadInterval(Duration.ofSeconds(1))
+                .withPostUploadFunction(events -> LOG.info("postUploadFunction triggered. Uploaded {} items", events.size()))
+                .withExceptionHandlerFunction(exception -> LOG.warn("exceptionHandlerFunction triggered: {}", exception.getMessage()));
+
+        for (TimeseriesPointPost dataPoint : upsertDataPointsList) {
+            uploadQueue.put(dataPoint);
+        }
+        uploadQueue.upload();
+
+        LOG.info(loggingPrefix + "Finished upserting data points. Duration: {}",
+                Duration.between(startInstant, Instant.now()));
+        LOG.info(loggingPrefix + "----------------------------------------------------------------------");
+
+        Thread.sleep(5000); // wait for eventual consistency
+
+        LOG.info(loggingPrefix + "Start reading timeseries.");
+        List<TimeseriesMetadata> listTimeseriesResults = new ArrayList<>();
+        client.timeseries()
+                .list(Request.create()
+                        .withFilterMetadataParameter("source", DataGenerator.sourceValue))
+                .forEachRemaining(timeseries -> listTimeseriesResults.addAll(timeseries));
+        LOG.info(loggingPrefix + "Finished reading timeseries. Duration: {}",
+                Duration.between(startInstant, Instant.now()));
+        LOG.info(loggingPrefix + "----------------------------------------------------------------------");
+
+        LOG.info(loggingPrefix + "Start reading data points.");
+        List<Item> listDataPointsItems = upsertTimeseriesList.stream()
+                .map(header -> Item.newBuilder()
+                        .setExternalId(header.getExternalId())
+                        .build())
+                .collect(Collectors.toList());
+        List<TimeseriesPoint> readDataPointsResults = new ArrayList<>();
+        client.timeseries().dataPoints().retrieveComplete(listDataPointsItems)
+                .forEachRemaining(timeseries -> readDataPointsResults.addAll(timeseries));
+        LOG.info(loggingPrefix + "Finished reading data points. Duration: {}",
+                Duration.between(startInstant, Instant.now()));
+        LOG.info(loggingPrefix + "----------------------------------------------------------------------");
+
+        LOG.info(loggingPrefix + "Start deleting timeseries.");
+        List<Item> deleteItemsInput = new ArrayList<>();
+        listTimeseriesResults.stream()
+                .map(timeseries -> Item.newBuilder()
+                        .setExternalId(timeseries.getExternalId())
+                        .build())
+                .forEach(item -> deleteItemsInput.add(item));
+
+        List<Item> deleteItemsResults = client.timeseries().delete(deleteItemsInput);
+        LOG.info(loggingPrefix + "Finished deleting timeseries. Duration: {}",
+                Duration.between(startInstant, Instant.now()));
+        LOG.info(loggingPrefix + "----------------------------------------------------------------------");
+
+        assertEquals(upsertDataPointsList.size(), readDataPointsResults.size());
+        assertEquals(upsertTimeseriesList.size(), listTimeseriesResults.size());
+        assertEquals(deleteItemsInput.size(), deleteItemsResults.size());
+    }
 }

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -19,10 +19,9 @@
     </appender>
 
     <logger name="com.cognite.client" level="INFO"/>
-    <!--
-    <logger name="com.cognite.client.ApiBase" level="INFO"/>
-    <logger name="com.cognite.client.RawRows" level="INFO"/>
-    -->
+    <!--logger name="com.cognite.client.ApiBase" level="DEBUG"/-->
+    <!--logger name="com.cognite.client.servicesV1.executor" level="DEBUG"/-->
+    <!--logger name="com.cognite.client.RawRows" level="INFO"/-->
 
     <root level="info">
         <appender-ref ref="STDOUT" />


### PR DESCRIPTION
Add upload queue functionality to all the main CDF resources. This mirrors the Python "extractor utils" and allows 1) performance optimization + less stress on the CDF API when upserting data and 2) ease of use for clients pushing data to CDF.