### PR TITLE
Datapoints cursor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,17 +42,17 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <auto.version>1.9</auto.version>
-        <nimbusds.version>9.41.1</nimbusds.version>
+        <nimbusds.version>9.43.1</nimbusds.version>
         <awss3.version>1.12.266</awss3.version>
         <jgrapht.version>1.5.1</jgrapht.version>
         <okhttp3.version>4.10.0</okhttp3.version>
-        <jackson.version>2.13.3</jackson.version>
-        <slf4j.version>1.7.36</slf4j.version>
+        <jackson.version>2.13.4</jackson.version>
+        <slf4j.version>2.0.3</slf4j.version>
         <guava.version>31.1-jre</guava.version>
         <commons.lang.version>3.12.0</commons.lang.version>
-        <logback.classic.version>1.2.11</logback.classic.version>
+        <logback.classic.version>1.4.1</logback.classic.version>
         <junit.version>5.9.0</junit.version>
-        <mockito.version>4.7.0</mockito.version>
+        <mockito.version>4.8.0</mockito.version>
 
         <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
         <maven-exec-plugin.version>3.0.0</maven-exec-plugin.version>
@@ -63,7 +63,7 @@
         <!-- protobuf paths -->
         <protobuf.input.directory>${project.basedir}/src/main/proto</protobuf.input.directory>
         <protobuf.output.directory>${project.build.directory}/generated-sources/proto</protobuf.output.directory>
-        <protobuf.version>3.21.5</protobuf.version>
+        <protobuf.version>3.21.7</protobuf.version>
 
         <build-helper-maven-plugin.version>3.2.0</build-helper-maven-plugin.version>
         <maven-antrun-plugin.version>3.0.0</maven-antrun-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <slf4j.version>2.0.3</slf4j.version>
         <guava.version>31.1-jre</guava.version>
         <commons.lang.version>3.12.0</commons.lang.version>
-        <logback.classic.version>1.4.1</logback.classic.version>
+        <logback.classic.version>1.4.3</logback.classic.version>
         <junit.version>5.9.0</junit.version>
         <mockito.version>4.8.0</mockito.version>
 

--- a/releases.md
+++ b/releases.md
@@ -21,6 +21,10 @@ Changes are grouped as follows:
 
 ### Added
 
+### Changed
+
+- `Data points` now uses the new cursor-based iteration offered by the API.
+
 ### Fixed
 
 - The default auth scope breaking when using certain combinations of `CogniteClient.withBaseUrl()` and `CogniteClient.withScopes()`.

--- a/src/main/java/com/cognite/client/ApiBase.java
+++ b/src/main/java/com/cognite/client/ApiBase.java
@@ -337,7 +337,7 @@ abstract class ApiBase {
             responseItems.addAll(responseItemsFuture.join().getResultsItems());
         }
 
-        LOG.info(batchLogPrefix + "Successfully retrieved {} items across {} requests within a duration of {}.",
+        LOG.debug(batchLogPrefix + "Successfully retrieved {} items across {} requests within a duration of {}.",
                 responseItems.size(),
                 futureList.size(),
                 Duration.between(startInstant, Instant.now()).toString());
@@ -405,7 +405,7 @@ abstract class ApiBase {
             LOG.error(message);
             throw new Exception(message);
         }
-        LOG.info(batchLogPrefix + "Successfully retrieved aggregate within a duration of {}.",
+        LOG.debug(batchLogPrefix + "Successfully retrieved aggregate within a duration of {}.",
                 Duration.between(startInstant, Instant.now()).toString());
         return AggregateParser.parseAggregate(responseItems.getResultsItems().get(0));
     }
@@ -2122,7 +2122,7 @@ abstract class ApiBase {
                                                        String errorMessage) throws Exception {
             // Check if all elements completed the upsert requests
             if (inputListA.isEmpty() && inputListB.isEmpty()) {
-                LOG.info(loggingPrefix + "Successfully upserted {} items within a duration of {}.",
+                LOG.debug(loggingPrefix + "Successfully upserted {} items within a duration of {}.",
                         outputList.size(),
                         Duration.between(startInstant, Instant.now()).toString());
             } else {

--- a/src/main/java/com/cognite/client/CogniteClient.java
+++ b/src/main/java/com/cognite/client/CogniteClient.java
@@ -44,7 +44,7 @@ public abstract class CogniteClient implements Serializable {
     private final static String API_ENV_VAR = "COGNITE_API_KEY";
 
     private static int DEFAULT_NO_WORKERS = 8;
-    private static int DEFAULT_NO_TS_WORKERS = 32;
+    private static int DEFAULT_NO_TS_WORKERS = 16;
     private static ThreadPoolExecutor executorService = new ThreadPoolExecutor(DEFAULT_NO_WORKERS, DEFAULT_NO_WORKERS,
             1000, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>());
     private static ThreadPoolExecutor tsExecutorService = new ThreadPoolExecutor(DEFAULT_NO_TS_WORKERS, DEFAULT_NO_TS_WORKERS,

--- a/src/main/java/com/cognite/client/DataPoints.java
+++ b/src/main/java/com/cognite/client/DataPoints.java
@@ -891,8 +891,15 @@ public abstract class DataPoints extends ApiBase implements UpsertTarget<Timeser
         /*
         Check if should do split by time. We need to check the following conditions:
         - Available capacity/workers after the above item split should be >= 50%.
+        - The request is for raw data points--not aggregates.
         - The query/request must specify the time window on the root level--not on the item level.
         - The query/request must specify a time window > 30 days.
+
+        If all conditions are satisfied, we start the time window split algorithm:
+        1) Check the first and last available timestamp of the TS items in CDF.
+        2) Re-calculate the query time-window based on 1) and check that it is >30 days
+        3) Calculate the number of time splits (based on available worker capacity).
+        4) Perform the time split.
          */
         if (splitsByItems.size() / (long) getClient().getClientConfig().getNoTsWorkers() > 0.5) {
             LOG.debug(loggingPrefix + "Splitting by time series items into {} requests offers good utilization of the available {} "
@@ -902,155 +909,124 @@ public abstract class DataPoints extends ApiBase implements UpsertTarget<Timeser
             return splitsByItems;
         }
 
+        // Check if there are any aggregate specifications in the original request.
+        if (requestParameters.getRequestParameters().containsKey(GRANULARITY_KEY)) {
+            LOG.debug(loggingPrefix + "The request specifies aggregates. Will not split further (by time window).");
+            return splitsByItems; // no splits
+        }
+
         for (Map<String, Object> tsItem : requestParameters.getItems()) {
-            if (tsItem.containsKey(START_KEY) || tsItem.containsKey(END_KEY)) {
-                LOG.debug(loggingPrefix + "The request specifies start/end on an item-level. "
+            if (tsItem.containsKey(START_KEY) || tsItem.containsKey(END_KEY) || tsItem.containsKey(GRANULARITY_KEY)) {
+                LOG.debug(loggingPrefix + "The request specifies start/end or granularity on an item-level. "
                                 + "Will not split further (by time window).");
                 return splitsByItems;
             }
         }
 
-        /*
-
-
-        // Split further by time windows.
         // Establish the request time window.
-        long startTimestamp = 0L;
-        long endTimestamp = Instant.now().truncatedTo(ChronoUnit.SECONDS).toEpochMilli();
+        long requestStartTimestamp = 0L;
+        long requestEndTimestamp = Instant.now().truncatedTo(ChronoUnit.SECONDS).toEpochMilli();
 
         LOG.debug(loggingPrefix + "Get end time from request attribute {}: [{}]",
                 END_KEY,
                 requestParameters.getRequestParameters().get(END_KEY));
         Optional<Long> requestEndTime = TSIterationUtilities.getEndAsMillis(requestParameters);
         if (requestEndTime.isPresent()) {
-            endTimestamp = requestEndTime.get();
+            requestEndTimestamp = requestEndTime.get();
         }
-
         LOG.debug(loggingPrefix + "Get start time from request attribute {}: [{}]",
                 START_KEY,
                 requestParameters.getRequestParameters().get(START_KEY));
         Optional<Long> requestStartTime = TSIterationUtilities.getStartAsMillis(requestParameters);
         if (requestStartTime.isPresent()) {
-            startTimestamp = requestStartTime.get();
+            requestStartTimestamp = requestStartTime.get();
         }
 
-        if (startTimestamp >= endTimestamp) {
+        if (requestStartTimestamp >= requestEndTimestamp) {
             LOG.error(loggingPrefix + "Request start time > end time. Request parameters: {}", requestParameters);
             throw new Exception(loggingPrefix + "Request start time >= end time.");
         }
-
-        // get the no items after the item split
-        int noTsItems = splitsByItems.get(0).getItems().size();
-        Duration duration = Duration.ofMillis(endTimestamp - startTimestamp);
-        // Minimum duration is set based on a TS with 1Hz frequency and 20 iterations. A single iteration
-        // captures ca. 24 hours (86400 data points at 1Hz) of data points.
-        final Duration SPLIT_LOWER_LIMIT = Duration.ofDays(Math.max(12, (240 / noTsItems)));
-
-        LOG.debug(loggingPrefix + "Splitting request with {} items, a duration of {} and a min time window of {}.",
-                noTsItems,
-                duration.toString(),
-                SPLIT_LOWER_LIMIT.toString());
-
-        if (duration.compareTo(SPLIT_LOWER_LIMIT) < 0) {
-            // The restriction range is too small to split.
-            LOG.info(loggingPrefix + "The request's time window is too small to split. Will just keep it as it is.");
+        Duration timeWindowDuration = Duration.ofMillis(requestEndTimestamp - requestStartTimestamp);
+        if (timeWindowDuration.compareTo(MIN_SPLIT_DURATION) < 0) {
+            // The time window is too small to split.
+            LOG.debug(loggingPrefix + "The request's time window is too small to split. Will just keep it as it is.");
             return splitsByItems;
         }
 
-        List<Request> splitByTimeWindow = new ArrayList<>();
-
-        if (requestParameters.getRequestParameters().containsKey(GRANULARITY_KEY)) {
-            // Run the aggregate split
-            return splitsByItems; // no splits
-        } else {
-            // We have raw data points and the request is "large" enough that we should get statistics to try and
-            // optimize the read requests.
-            // Get start and end of time window based on first and last available data point.
-            List<Item> tsItems = new ArrayList<>();
-            for (Map<String, Object> itemEntry : requestParameters.getItems()) {
-                if (itemEntry.containsKey("externalId")) {
-                    tsItems.add(Item.newBuilder()
-                            .setExternalId((String) itemEntry.get("externalId"))
-                            .build());
-                } else {
-                    tsItems.add(Item.newBuilder()
-                            .setId((long) itemEntry.get("id"))
-                            .build());
-                }
-            }
-            long estimatedEndTimestamp = this.retrieveLatest(tsItems).stream()
-                    .mapToLong(dataPoint -> dataPoint.getTimestamp())
-                    .max()
-                    .orElse(endTimestamp);
-            estimatedEndTimestamp += 10; // add a bit of buffer.
-            long estimatedStartTimestamp = this.retrieveFirst(tsItems).stream()
-                    .mapToLong(dataPoint -> dataPoint.getTimestamp())
-                    .min()
-                    .orElse(startTimestamp);
-            estimatedStartTimestamp -= 10; // add a bit of buffer.
-            startTimestamp = estimatedStartTimestamp > startTimestamp ? estimatedStartTimestamp : startTimestamp;
-            endTimestamp = estimatedEndTimestamp < endTimestamp ? estimatedEndTimestamp : endTimestamp;
-
-            // Check the max frequency
-            double maxFrequency = getMaxFrequency(requestParameters,
-                    Instant.ofEpochMilli(startTimestamp),
-                    Instant.ofEpochMilli(endTimestamp));
-            if (maxFrequency == 0d) {
-                // no datapoints in the range--don't split it
-                LOG.warn(loggingPrefix + "Unable to build statistics for the restriction / range. No counts. "
-                        + "Will keep the original range/restriction.");
-                return splitsByItems;
-            }
-            LOG.debug(loggingPrefix + "Collected basic statistics. "
-                            + "Capacity: {}, No splits by item: {}, Max frequency: {}, No TS items: {}, Time window seconds: {}",
-                            capacity,
-                            splitsByItems.size(),
-                            maxFrequency,
-                            noTsItems,
-                            Duration.ofMillis(endTimestamp - startTimestamp).getSeconds());
-
-            // Calculate the number of splits by time window.
-            long maxSplitsByCapacity = Math.floorDiv(capacity, splitsByItems.size()); // may result in zero
-            long estimatedNoDataPoints = (long) (maxFrequency * noTsItems * Duration.ofMillis(endTimestamp - startTimestamp).getSeconds());
-            long minDataPointsPerRequest = 100_000 * 10L;
-            long maxSplitsByFrequency = Math.floorDiv(estimatedNoDataPoints, minDataPointsPerRequest); // may result in zero
-            long targetNoSplits = Math.min(maxSplitsByCapacity, maxSplitsByFrequency);
-            LOG.debug(loggingPrefix + "Calculating the number of splits by time window. "
-                    + "Max splits by capacity: {}, estimated no data points: {}, max splits by frequency: {}, "
-                    + "target no splits: {}",
-                    maxSplitsByCapacity,
-                    estimatedNoDataPoints,
-                    maxSplitsByFrequency,
-                    targetNoSplits);
-
-            if (targetNoSplits <= 1) {
-                // no need to split further
-                return splitsByItems;
-            }
-            long splitDelta = Math.floorDiv(endTimestamp - startTimestamp, targetNoSplits);
-            long previousEnd = startTimestamp;
-            for (int i = 0; i < targetNoSplits; i++) {
-                long deltaStart = previousEnd;
-                long deltaEnd = deltaStart + splitDelta;
-                previousEnd = deltaEnd;
-                if (i == targetNoSplits - 1) {
-                    // We are on the final iteration, so make sure we include the rest of the time range.
-                    deltaEnd = endTimestamp;
-                }
-                for (Request request : splitsByItems) {
-                    LOG.debug(loggingPrefix + "Adding time based split with start {} and end {}",
-                            deltaStart,
-                            deltaEnd);
-                    splitByTimeWindow.add(request
-                            .withRootParameter(START_KEY, deltaStart)
-                            .withRootParameter(END_KEY, deltaEnd));
-                }
+        // All conditions for splitting by time window has been satisfied. Let's calculate the split.
+        // Get start and end of time window based on first and last available data point.
+        List<Item> tsItems = new ArrayList<>();
+        for (Map<String, Object> itemEntry : requestParameters.getItems()) {
+            if (itemEntry.containsKey("externalId")) {
+                tsItems.add(Item.newBuilder()
+                        .setExternalId((String) itemEntry.get("externalId"))
+                        .build());
+            } else {
+                tsItems.add(Item.newBuilder()
+                        .setId((long) itemEntry.get("id"))
+                        .build());
             }
         }
+        long estimatedEndTimestamp = this.retrieveLatest(tsItems).stream()
+                .mapToLong(dataPoint -> dataPoint.getTimestamp())
+                .max()
+                .orElse(requestEndTimestamp);
+        estimatedEndTimestamp += 10; // add a bit of buffer.
+        long estimatedStartTimestamp = this.retrieveFirst(tsItems).stream()
+                .mapToLong(dataPoint -> dataPoint.getTimestamp())
+                .min()
+                .orElse(requestStartTimestamp);
+        estimatedStartTimestamp -= 10; // add a bit of buffer.
+        long startTimestamp = estimatedStartTimestamp > requestStartTimestamp ? estimatedStartTimestamp : requestStartTimestamp;
+        long endTimestamp = estimatedEndTimestamp < requestEndTimestamp ? estimatedEndTimestamp : requestEndTimestamp;
 
+        // Check the time window duration again
+        timeWindowDuration = Duration.ofMillis(endTimestamp - startTimestamp);
+        if (timeWindowDuration.compareTo(MIN_SPLIT_DURATION) < 0) {
+            // The time window is too small to split.
+            LOG.debug(loggingPrefix + "The available data points' time window is too small to split. Will just keep it as it is.");
+            return splitsByItems;
+        }
+
+        // Calculate the number of splits by time window.
+        long targetNoSplits = getClient().getClientConfig().getNoTsWorkers() / splitsByItems.size(); // may result in zero
+        LOG.debug(loggingPrefix + "Calculating the number of splits by time window. "
+                        + "Capacity: {}, current partitions by item: {}, target no splits: {}",
+                getClient().getClientConfig().getNoTsWorkers(),
+                splitsByItems.size(),
+                targetNoSplits);
+
+        if (targetNoSplits <= 1) {
+            // no need to split further
+            return splitsByItems;
+        }
+
+        // Calculate the number of splits by time window.
+        List<Request> splitByTimeWindow = new ArrayList<>();
+        long splitDelta = Math.floorDiv(endTimestamp - startTimestamp, targetNoSplits);
+        long previousEnd = startTimestamp;
+        for (int i = 0; i < targetNoSplits; i++) {
+            long deltaStart = previousEnd;
+            long deltaEnd = deltaStart + splitDelta;
+            previousEnd = deltaEnd;
+            if (i == 0) {
+                // We are on the first interval, so make sure we include the original start time stamp.
+                deltaStart = requestStartTimestamp;
+            }
+            if (i == targetNoSplits - 1) {
+                // We are on the final interval, so make sure we include the rest of the time range.
+                deltaEnd = requestEndTimestamp;
+            }
+            for (Request request : splitsByItems) {
+                LOG.debug(loggingPrefix + "Adding time based split with start {} and end {}",
+                        deltaStart,
+                        deltaEnd);
+                splitByTimeWindow.add(request
+                        .withRootParameter(START_KEY, deltaStart)
+                        .withRootParameter(END_KEY, deltaEnd));
+            }
+        }
         return splitByTimeWindow;
-
-         */
     }
 
     /**

--- a/src/main/java/com/cognite/client/config/ClientConfig.java
+++ b/src/main/java/com/cognite/client/config/ClientConfig.java
@@ -28,6 +28,7 @@ public abstract class ClientConfig implements Serializable {
 
     // Thread pool capacity
     private final static int DEFAULT_CPU_THREADS = 8;
+    private final static int DEFAULT_CPU_THREADS_TS = 32;
 
     // Connection retries
     private static final int DEFAULT_RETRIES = 5;
@@ -55,6 +56,7 @@ public abstract class ClientConfig implements Serializable {
                 .setSessionIdentifier(DEFAULT_SESSION_IDENTIFIER)
                 .setMaxRetries(DEFAULT_RETRIES)
                 .setNoWorkers(DEFAULT_CPU_THREADS)
+                .setNoTsWorkers(DEFAULT_CPU_THREADS_TS)
                 .setNoListPartitions(DEFAULT_LIST_PARTITIONS)
                 .setUpsertMode(DEFAULT_UPSERT_MODE)
                 .setEntityMatchingMaxBatchSize(DEFAULT_ENTITY_MATCHING_MAX_BATCH_SIZE)
@@ -77,6 +79,7 @@ public abstract class ClientConfig implements Serializable {
     public abstract String getSessionIdentifier();
     public abstract int getMaxRetries();
     public abstract int getNoWorkers();
+    public abstract int getNoTsWorkers();
     public abstract int getNoListPartitions();
     public abstract UpsertMode getUpsertMode();
     public abstract int getEntityMatchingMaxBatchSize();
@@ -145,6 +148,18 @@ public abstract class ClientConfig implements Serializable {
      */
     public ClientConfig withNoListPartitions(int noPartitions) {
         return toBuilder().setNoListPartitions(noPartitions).build();
+    }
+
+    /**
+     * Specifies the maximum number of workers to use for the Cognite API requests towards the time series service.
+     * This is a high-capacity service optimized for a higher number of workers than the other API services. The default
+     * setting is 32 workers.
+     *
+     * @param noTsWorkers max number of workers.
+     * @return the {@link ClientConfig} with the setting applied.
+     */
+    public ClientConfig withNoTsWorkers(int noTsWorkers) {
+        return toBuilder().setNoTsWorkers(noTsWorkers).build();
     }
 
     /**
@@ -220,6 +235,7 @@ public abstract class ClientConfig implements Serializable {
         abstract Builder setSessionIdentifier(String value);
         abstract Builder setMaxRetries(int value);
         abstract Builder setNoWorkers(int value);
+        abstract Builder setNoTsWorkers(int value);
         abstract Builder setNoListPartitions(int value);
         abstract Builder setUpsertMode(UpsertMode value);
         abstract Builder setEntityMatchingMaxBatchSize(int value);

--- a/src/main/java/com/cognite/client/config/ClientConfig.java
+++ b/src/main/java/com/cognite/client/config/ClientConfig.java
@@ -28,7 +28,7 @@ public abstract class ClientConfig implements Serializable {
 
     // Thread pool capacity
     private final static int DEFAULT_CPU_THREADS = 8;
-    private final static int DEFAULT_CPU_THREADS_TS = 32;
+    private final static int DEFAULT_CPU_THREADS_TS = 16;
 
     // Connection retries
     private static final int DEFAULT_RETRIES = 5;
@@ -153,7 +153,7 @@ public abstract class ClientConfig implements Serializable {
     /**
      * Specifies the maximum number of workers to use for the Cognite API requests towards the time series service.
      * This is a high-capacity service optimized for a higher number of workers than the other API services. The default
-     * setting is 32 workers.
+     * setting is 16 workers.
      *
      * @param noTsWorkers max number of workers.
      * @return the {@link ClientConfig} with the setting applied.

--- a/src/main/java/com/cognite/client/servicesV1/ConnectorServiceV1.java
+++ b/src/main/java/com/cognite/client/servicesV1/ConnectorServiceV1.java
@@ -591,8 +591,6 @@ public abstract class ConnectorServiceV1 implements Serializable {
      * @return
      */
     public ResultFutureIterator<String> readTsDatapoints(Request queryParameters) {
-        LOG.debug(loggingPrefix + "Initiating read TS datapoints service.");
-
         TSPointsRequestProvider requestProvider = TSPointsRequestProvider.builder()
                 .setEndpoint("timeseries/data/list")
                 .setRequest(queryParameters)
@@ -613,11 +611,8 @@ public abstract class ConnectorServiceV1 implements Serializable {
      * @param queryParameters The parameters for the events query.
      * @return
      */
-    public ResultFutureIterator<DataPointListItem>
-            readTsDatapointsProto(Request queryParameters) {
-        LOG.debug(loggingPrefix + "Initiating read TS datapoints service.");
-
-        TSPointsReadProtoRequestProvider requestProvider = TSPointsReadProtoRequestProvider.builder()
+    public ResultFutureIterator<DataPointListItem> readTsDatapointsProto(Request queryParameters) {
+        TSPointsReadProtoCursorsRequestProvider requestProvider = TSPointsReadProtoCursorsRequestProvider.builder()
                 .setEndpoint("timeseries/data/list")
                 .setRequest(queryParameters)
                 .setSdkIdentifier(getClient().getClientConfig().getSdkIdentifier())
@@ -625,7 +620,7 @@ public abstract class ConnectorServiceV1 implements Serializable {
                 .setSessionIdentifier(getClient().getClientConfig().getSessionIdentifier())
                 .build();
 
-        TSPointsProtoResponseParser responseParser = TSPointsProtoResponseParser.builder().build()
+        TSPointsProtoCursorsResponseParser responseParser = TSPointsProtoCursorsResponseParser.builder().build()
                 .withRequest(queryParameters);
 
         return ResultFutureIterator.<DataPointListItem>of(getClient(), requestProvider, responseParser);

--- a/src/main/java/com/cognite/client/servicesV1/executor/RequestExecutor.java
+++ b/src/main/java/com/cognite/client/servicesV1/executor/RequestExecutor.java
@@ -65,8 +65,6 @@ public abstract class RequestExecutor {
     private static final ThreadPoolExecutor DEFAULT_POOL = new ThreadPoolExecutor(NO_WORKERS, NO_WORKERS,
             1000, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>());
 
-    //private static final ForkJoinPool DEFAULT_POOL = new ForkJoinPool();
-
     static {
         DEFAULT_POOL.allowCoreThreadTimeOut(true);
     }

--- a/src/main/java/com/cognite/client/servicesV1/request/TSPointsReadProtoCursorsRequestProvider.java
+++ b/src/main/java/com/cognite/client/servicesV1/request/TSPointsReadProtoCursorsRequestProvider.java
@@ -123,10 +123,13 @@ public abstract class TSPointsReadProtoCursorsRequestProvider extends GenericReq
                 requestParameters.getItems().size());
 
         requestParameters = requestParameters.withRootParameter("limit", newLimit);
-        LOG.debug(logPrefix + "Adjusted the limit based on the number of TS items. New limit: " + newLimit);
+        LOG.debug(logPrefix + "Adjusted the *limit* based on the number of TS items in the request ({}). New limit: {}",
+                requestParameters.getItems().size(),
+                newLimit);
 
         String outputJson = requestParameters.getRequestParametersAsJson();
-        LOG.debug("TSPointsReadRequestProvider: Json request body: {}", outputJson);
+        LOG.debug(logPrefix + "Request headers: {}", requestBuilder.build().headers().toString());
+        LOG.debug(logPrefix + "Json request body: {}", outputJson);
         requestBuilder.header("Accept", "application/protobuf");
         return requestBuilder.post(RequestBody.Companion.create(outputJson, MediaType.get("application/json"))).build();
     }
@@ -139,7 +142,7 @@ public abstract class TSPointsReadProtoCursorsRequestProvider extends GenericReq
     @Override
     protected okhttp3.Request.Builder buildGenericRequest() throws URISyntaxException {
         okhttp3.Request.Builder reqBuilder = super.buildGenericRequest();
-        reqBuilder.addHeader("version", "alpha");
+        reqBuilder.addHeader("cdf-version", "alpha");
 
         return reqBuilder;
     }

--- a/src/main/java/com/cognite/client/servicesV1/request/TSPointsReadProtoCursorsRequestProvider.java
+++ b/src/main/java/com/cognite/client/servicesV1/request/TSPointsReadProtoCursorsRequestProvider.java
@@ -62,7 +62,6 @@ public abstract class TSPointsReadProtoCursorsRequestProvider extends GenericReq
     }
 
     public okhttp3.Request buildRequest(Optional<String> cursor) throws Exception {
-        final String randomString = RandomStringUtils.randomAlphanumeric(5);
         final String logPrefix = "Build read TS datapoints request - ";
         Request requestParameters = getRequest();
         okhttp3.Request.Builder requestBuilder = buildGenericRequest();
@@ -101,7 +100,7 @@ public abstract class TSPointsReadProtoCursorsRequestProvider extends GenericReq
                     cursorItem = getCursorObjectFromId(cursorList, (Long) item.getOrDefault("id", 0l));
                 }
 
-                // Check that the id exits in the cursor map. If yes, add the item and set the new *start* parameter
+                // Check that the id exits in the cursor map. If yes, add the item and set the *cursor* parameter
                 if (cursorItem.isPresent()) {
                     Map<String, Object> newItem = new HashMap<>();
                     newItem.putAll(item);

--- a/src/main/java/com/cognite/client/servicesV1/request/TSPointsReadProtoCursorsRequestProvider.java
+++ b/src/main/java/com/cognite/client/servicesV1/request/TSPointsReadProtoCursorsRequestProvider.java
@@ -30,6 +30,7 @@ import okhttp3.MediaType;
 import okhttp3.RequestBody;
 import org.apache.commons.lang3.RandomStringUtils;
 
+import java.net.URISyntaxException;
 import java.util.*;
 
 @AutoValue
@@ -91,7 +92,7 @@ public abstract class TSPointsReadProtoCursorsRequestProvider extends GenericReq
             ImmutableList<ImmutableMap<String, Object>> originalItems = requestParameters.getItems();
             List<Map<String, Object>> requestItems = new ArrayList<>();
             for (ImmutableMap<String, Object> item : originalItems) {
-                Optional<Map<String, Object>> cursorItem = Optional.empty();
+                Optional<Map<String, Object>> cursorItem;
                 // get the id of the item. Can be either externalId or id
                 String externalId = (String) item.getOrDefault("externalId", "");
                 if (!externalId.isBlank()) {
@@ -128,6 +129,19 @@ public abstract class TSPointsReadProtoCursorsRequestProvider extends GenericReq
         LOG.debug("TSPointsReadRequestProvider: Json request body: {}", outputJson);
         requestBuilder.header("Accept", "application/protobuf");
         return requestBuilder.post(RequestBody.Companion.create(outputJson, MediaType.get("application/json"))).build();
+    }
+
+    /**
+     * Add the alpha flag to the request.
+     * @return
+     * @throws URISyntaxException
+     */
+    @Override
+    protected okhttp3.Request.Builder buildGenericRequest() throws URISyntaxException {
+        okhttp3.Request.Builder reqBuilder = super.buildGenericRequest();
+        reqBuilder.addHeader("version", "alpha");
+
+        return reqBuilder;
     }
 
     private Optional<Map<String, Object>> getCursorObjectFromId(List<Map<String, Object>> cursorList, long id) {

--- a/src/main/java/com/cognite/client/servicesV1/request/TSPointsReadProtoCursorsRequestProvider.java
+++ b/src/main/java/com/cognite/client/servicesV1/request/TSPointsReadProtoCursorsRequestProvider.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2020 Cognite AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cognite.client.servicesV1.request;
+
+import com.cognite.client.Request;
+import com.cognite.client.servicesV1.ConnectorConstants;
+import com.cognite.client.servicesV1.util.JsonUtil;
+import com.cognite.client.servicesV1.util.TSIterationUtilities;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.google.auto.value.AutoValue;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import okhttp3.MediaType;
+import okhttp3.RequestBody;
+import org.apache.commons.lang3.RandomStringUtils;
+
+import java.util.*;
+
+@AutoValue
+public abstract class TSPointsReadProtoCursorsRequestProvider extends GenericRequestProvider {
+    private static final int MAX_TS_ITEMS = 100;
+
+    private final ObjectReader objectReader = JsonUtil.getObjectMapperInstance().reader();
+
+    public static Builder builder() {
+        return new AutoValue_TSPointsReadProtoCursorsRequestProvider.Builder()
+                .setRequest(Request.create())
+                .setSdkIdentifier(ConnectorConstants.SDK_IDENTIFIER)
+                .setAppIdentifier(ConnectorConstants.DEFAULT_APP_IDENTIFIER)
+                .setSessionIdentifier(ConnectorConstants.DEFAULT_SESSION_IDENTIFIER)
+                .setBetaEnabled(ConnectorConstants.DEFAULT_BETA_ENABLED);
+    }
+
+    public abstract Builder toBuilder();
+
+    public TSPointsReadProtoCursorsRequestProvider withRequest(Request parameters) {
+        Preconditions.checkNotNull(parameters, "Request parameters cannot be null.");
+        Preconditions.checkArgument(parameters.getItems().size() <= MAX_TS_ITEMS,
+                "Datapoints can only be requested for maximum " + MAX_TS_ITEMS + " time series per request.");
+        Preconditions.checkArgument(parameters.getItems().get(0).containsKey("id")
+                || parameters.getItems().get(0).containsKey("externalId"),
+                "The request must contain an id or externalId");
+
+        return toBuilder().setRequest(parameters).build();
+    }
+
+    public okhttp3.Request buildRequest(Optional<String> cursor) throws Exception {
+        final String randomString = RandomStringUtils.randomAlphanumeric(5);
+        final String logPrefix = "Build read TS datapoints request - ";
+        Request requestParameters = getRequest();
+        okhttp3.Request.Builder requestBuilder = buildGenericRequest();
+
+        // Check for limit
+        if (!requestParameters.getRequestParameters().containsKey("limit")) {
+            if (requestParameters.getRequestParameters().containsKey("aggregates")) {
+                requestParameters = requestParameters.withRootParameter("limit",
+                        ConnectorConstants.DEFAULT_MAX_BATCH_SIZE_TS_DATAPOINTS_AGG);
+                LOG.info(logPrefix + "Request does not contain a *limit* parameter. Setting default limit: "
+                        + ConnectorConstants.DEFAULT_MAX_BATCH_SIZE_TS_DATAPOINTS);
+            } else {
+                requestParameters = requestParameters.withRootParameter("limit",
+                        ConnectorConstants.DEFAULT_MAX_BATCH_SIZE_TS_DATAPOINTS);
+                LOG.info(logPrefix + "Request does not contain a *limit* parameter. Setting default limit: "
+                        + ConnectorConstants.DEFAULT_MAX_BATCH_SIZE_TS_DATAPOINTS);
+            }
+        }
+
+        if (cursor.isPresent()) {
+            LOG.debug(logPrefix + "Adding cursor to the request.");
+            LOG.debug(logPrefix + "Cursor: \r\n" + cursor.get());
+            // The cursor should be a map of all (valid) TS items and their start timestamp
+            ImmutableList<Map<String, Object>> cursorList = ImmutableList.copyOf(
+                    objectReader.forType(new TypeReference<List<Map<String, Object>>>(){})
+                            .<List<Map<String, Object>>>readValue(cursor.get()));
+            ImmutableList<ImmutableMap<String, Object>> originalItems = requestParameters.getItems();
+            List<Map<String, Object>> requestItems = new ArrayList<>();
+            for (ImmutableMap<String, Object> item : originalItems) {
+                Optional<Map<String, Object>> cursorItem = Optional.empty();
+                // get the id of the item. Can be either externalId or id
+                String externalId = (String) item.getOrDefault("externalId", "");
+                if (!externalId.isEmpty()) {
+                    cursorItem = getCursorObjectFromExternalId(cursorList, externalId);
+                } else {
+                    cursorItem = getCursorObjectFromId(cursorList, (Long) item.getOrDefault("id", 0l));
+                }
+
+                // Check that the id exits in the cursor map. If yes, add the item and set the new *start* parameter
+                if (cursorItem.isPresent()) {
+                    Map<String, Object> newItem = new HashMap<>();
+                    newItem.putAll(item);
+                    newItem.put("start", cursorItem.get().get("timestamp"));
+                    requestItems.add(newItem);
+                }
+            }
+            requestParameters = requestParameters.withItems(requestItems);
+        }
+        // Check that the request parameters contains items
+        if (requestParameters.getItems().isEmpty()) {
+            LOG.warn(logPrefix + "No items in the request parameters. Cannot build a valid request. \r\n {}",
+                    requestParameters);
+            throw new Exception(logPrefix + "No items in the request parameters. Cannot build a valid request.");
+        }
+
+        // Adjust the limit based on the number of TS in the request
+        int newLimit = TSIterationUtilities.calculateLimit((Integer) requestParameters.getRequestParameters().get("limit"),
+                requestParameters.getItems().size());
+
+        requestParameters = requestParameters.withRootParameter("limit", newLimit);
+        LOG.debug(logPrefix + "Adjusted the limit based on the number of TS items. New limit: " + newLimit);
+
+        String outputJson = requestParameters.getRequestParametersAsJson();
+        LOG.debug("TSPointsReadRequestProvider: Json request body: {}", outputJson);
+        requestBuilder.header("Accept", "application/protobuf");
+        return requestBuilder.post(RequestBody.Companion.create(outputJson, MediaType.get("application/json"))).build();
+    }
+
+    private Optional<Map<String, Object>> getCursorObjectFromId(List<Map<String, Object>> cursorList, long id) {
+        ImmutableMap<String, Object> cursorObject = null;
+        for (Map<String, Object> item : cursorList) {
+            if ((Long) item.getOrDefault("id", 0l) == id) {
+                cursorObject = ImmutableMap.copyOf(item);
+            }
+        }
+        return Optional.ofNullable(cursorObject);
+    }
+
+    private Optional<Map<String, Object>> getCursorObjectFromExternalId(List<Map<String, Object>> cursorList, String externalId) {
+        ImmutableMap<String, Object> cursorObject = null;
+        for (Map<String, Object> item : cursorList) {
+            if (((String) item.getOrDefault("externalId", "")).equals(externalId)) {
+                cursorObject = ImmutableMap.copyOf(item);
+            }
+        }
+        return Optional.ofNullable(cursorObject);
+    }
+
+    @AutoValue.Builder
+    public static abstract class Builder extends GenericRequestProvider.Builder<Builder>{
+        public abstract TSPointsReadProtoCursorsRequestProvider build();
+    }
+}

--- a/src/main/java/com/cognite/client/servicesV1/request/TSPointsReadProtoCursorsRequestProvider.java
+++ b/src/main/java/com/cognite/client/servicesV1/request/TSPointsReadProtoCursorsRequestProvider.java
@@ -94,7 +94,7 @@ public abstract class TSPointsReadProtoCursorsRequestProvider extends GenericReq
                 Optional<Map<String, Object>> cursorItem = Optional.empty();
                 // get the id of the item. Can be either externalId or id
                 String externalId = (String) item.getOrDefault("externalId", "");
-                if (!externalId.isEmpty()) {
+                if (!externalId.isBlank()) {
                     cursorItem = getCursorObjectFromExternalId(cursorList, externalId);
                 } else {
                     cursorItem = getCursorObjectFromId(cursorList, (Long) item.getOrDefault("id", 0l));
@@ -104,7 +104,7 @@ public abstract class TSPointsReadProtoCursorsRequestProvider extends GenericReq
                 if (cursorItem.isPresent()) {
                     Map<String, Object> newItem = new HashMap<>();
                     newItem.putAll(item);
-                    newItem.put("start", cursorItem.get().get("timestamp"));
+                    newItem.put("cursor", cursorItem.get().get("nextCursor"));
                     requestItems.add(newItem);
                 }
             }

--- a/src/main/java/com/cognite/client/servicesV1/request/TSPointsReadProtoCursorsRequestProvider.java
+++ b/src/main/java/com/cognite/client/servicesV1/request/TSPointsReadProtoCursorsRequestProvider.java
@@ -73,7 +73,7 @@ public abstract class TSPointsReadProtoCursorsRequestProvider extends GenericReq
                 requestParameters = requestParameters.withRootParameter("limit",
                         ConnectorConstants.DEFAULT_MAX_BATCH_SIZE_TS_DATAPOINTS_AGG);
                 LOG.info(logPrefix + "Request does not contain a *limit* parameter. Setting default limit: "
-                        + ConnectorConstants.DEFAULT_MAX_BATCH_SIZE_TS_DATAPOINTS);
+                        + ConnectorConstants.DEFAULT_MAX_BATCH_SIZE_TS_DATAPOINTS_AGG);
             } else {
                 requestParameters = requestParameters.withRootParameter("limit",
                         ConnectorConstants.DEFAULT_MAX_BATCH_SIZE_TS_DATAPOINTS);

--- a/src/main/java/com/cognite/client/servicesV1/request/TSPointsReadProtoRequestProvider.java
+++ b/src/main/java/com/cognite/client/servicesV1/request/TSPointsReadProtoRequestProvider.java
@@ -21,7 +21,6 @@ import com.cognite.client.Request;
 import com.cognite.client.servicesV1.util.JsonUtil;
 import com.cognite.client.servicesV1.util.TSIterationUtilities;
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Preconditions;

--- a/src/main/java/com/cognite/client/servicesV1/request/TSPointsReadProtoRequestProvider.java
+++ b/src/main/java/com/cognite/client/servicesV1/request/TSPointsReadProtoRequestProvider.java
@@ -18,6 +18,7 @@ package com.cognite.client.servicesV1.request;
 
 import com.cognite.client.servicesV1.ConnectorConstants;
 import com.cognite.client.Request;
+import com.cognite.client.servicesV1.util.JsonUtil;
 import com.cognite.client.servicesV1.util.TSIterationUtilities;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -34,10 +35,9 @@ import java.util.*;
 
 @AutoValue
 public abstract class TSPointsReadProtoRequestProvider extends GenericRequestProvider {
-    private static final ObjectMapper mapper = new ObjectMapper();
     private static final int MAX_TS_ITEMS = 100;
 
-    private final ObjectReader objectReader = mapper.reader();
+    private final ObjectReader objectReader = JsonUtil.getObjectMapperInstance().reader();
 
     public static Builder builder() {
         return new com.cognite.client.servicesV1.request.AutoValue_TSPointsReadProtoRequestProvider.Builder()
@@ -75,7 +75,7 @@ public abstract class TSPointsReadProtoRequestProvider extends GenericRequestPro
                 requestParameters = requestParameters.withRootParameter("limit",
                         ConnectorConstants.DEFAULT_MAX_BATCH_SIZE_TS_DATAPOINTS_AGG);
                 LOG.info(logPrefix + "Request does not contain a *limit* parameter. Setting default limit: "
-                        + ConnectorConstants.DEFAULT_MAX_BATCH_SIZE_TS_DATAPOINTS);
+                        + ConnectorConstants.DEFAULT_MAX_BATCH_SIZE_TS_DATAPOINTS_AGG);
             } else {
                 requestParameters = requestParameters.withRootParameter("limit",
                         ConnectorConstants.DEFAULT_MAX_BATCH_SIZE_TS_DATAPOINTS);

--- a/src/main/java/com/cognite/client/servicesV1/request/TSPointsRequestProvider.java
+++ b/src/main/java/com/cognite/client/servicesV1/request/TSPointsRequestProvider.java
@@ -18,17 +18,23 @@ package com.cognite.client.servicesV1.request;
 
 import com.cognite.client.servicesV1.ConnectorConstants;
 import com.cognite.client.Request;
+import com.cognite.client.servicesV1.util.JsonUtil;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectReader;
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import okhttp3.MediaType;
 import okhttp3.RequestBody;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.util.Optional;
+import java.util.*;
 
 @AutoValue
 public abstract class TSPointsRequestProvider extends GenericRequestProvider {
+    private final ObjectReader objectReader = JsonUtil.getObjectMapperInstance().reader();
 
     public static Builder builder() {
         return new com.cognite.client.servicesV1.request.AutoValue_TSPointsRequestProvider.Builder()
@@ -59,6 +65,7 @@ public abstract class TSPointsRequestProvider extends GenericRequestProvider {
     }
 
     public okhttp3.Request buildRequest(Optional<String> cursor) throws IOException, URISyntaxException {
+        final String logPrefix = "Build read TS datapoints request - ";
         Request requestParameters = getRequest();
         okhttp3.Request.Builder requestBuilder = buildGenericRequest();
 
@@ -69,12 +76,70 @@ public abstract class TSPointsRequestProvider extends GenericRequestProvider {
         }
 
         if (cursor.isPresent()) {
-            requestParameters = requestParameters.withRootParameter("start", cursor.get());
+            LOG.debug(logPrefix + "Adding cursor to the request.");
+            LOG.debug(logPrefix + "Cursor: \r\n" + cursor.get());
+            // The cursor should be a map of all (valid) TS items and their start timestamp
+            List<Map<String, Object>> cursorList = objectReader.forType(new TypeReference<List<Map<String, Object>>>(){})
+                            .<List<Map<String, Object>>>readValue(cursor.get());
+
+            ImmutableList<ImmutableMap<String, Object>> originalItems = requestParameters.getItems();
+            List<Map<String, Object>> requestItems = new ArrayList<>();
+            for (ImmutableMap<String, Object> item : originalItems) {
+                Optional<Map<String, Object>> cursorItem;
+                // get the id of the item. Can be either externalId or id
+                String externalId = (String) item.getOrDefault("externalId", "");
+                if (!externalId.isEmpty()) {
+                    cursorItem = getCursorObjectFromExternalId(cursorList, externalId);
+                } else {
+                    cursorItem = getCursorObjectFromId(cursorList, (Long) item.getOrDefault("id", 0l));
+                }
+
+                // Check that the id exits in the cursor map. If yes, add the item
+                if (cursorItem.isPresent()) {
+                    Map<String, Object> newItem = new HashMap<>();
+                    newItem.putAll(item);
+                    newItem.put("cursor", cursorItem.get().get("nextCursor"));
+                    requestItems.add(newItem);
+
+                    // remove the cursor from the original list so we can do some "accounting" at the end.
+                    cursorList.remove(cursorItem);
+                }
+            }
+
+            if (cursorList.size() > 0) {
+                // We have some cursors that have not been applied--this should not happen
+                LOG.warn(logPrefix + "Mismatch between nextCursor and the data points request. {} cursors don't have a "
+                        + "corresponding request item. Surplus cursors: \n{}",
+                        cursorList.size(),
+                        cursorList);
+            }
+
+            requestParameters = requestParameters.withItems(requestItems);
         }
 
         String outputJson = requestParameters.getRequestParametersAsJson();
         LOG.debug("Json request body: {}", outputJson);
         return requestBuilder.post(RequestBody.Companion.create(outputJson, MediaType.get("application/json"))).build();
+    }
+
+    private Optional<Map<String, Object>> getCursorObjectFromId(List<Map<String, Object>> cursorList, long id) {
+        ImmutableMap<String, Object> cursorObject = null;
+        for (Map<String, Object> item : cursorList) {
+            if ((Long) item.getOrDefault("id", 0l) == id) {
+                cursorObject = ImmutableMap.copyOf(item);
+            }
+        }
+        return Optional.ofNullable(cursorObject);
+    }
+
+    private Optional<Map<String, Object>> getCursorObjectFromExternalId(List<Map<String, Object>> cursorList, String externalId) {
+        ImmutableMap<String, Object> cursorObject = null;
+        for (Map<String, Object> item : cursorList) {
+            if (((String) item.getOrDefault("externalId", "")).equals(externalId)) {
+                cursorObject = ImmutableMap.copyOf(item);
+            }
+        }
+        return Optional.ofNullable(cursorObject);
     }
 
     @AutoValue.Builder

--- a/src/main/java/com/cognite/client/servicesV1/response/TSPointsProtoCursorsResponseParser.java
+++ b/src/main/java/com/cognite/client/servicesV1/response/TSPointsProtoCursorsResponseParser.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright (c) 2020 Cognite AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cognite.client.servicesV1.response;
+
+import com.cognite.client.Request;
+import com.cognite.client.servicesV1.util.JsonUtil;
+import com.cognite.client.servicesV1.util.TSIterationUtilities;
+import com.cognite.v1.timeseries.proto.*;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.google.auto.value.AutoValue;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.*;
+
+@AutoValue
+public abstract class TSPointsProtoCursorsResponseParser implements ResponseParser<DataPointListItem> {
+    private static final int DEFAULT_PARAMETER_LIMIT = 10000;
+
+    private static final String END_KEY = "end";
+    private static final String GRANULARITY_KEY = "granularity";
+
+    private final Logger LOG = LoggerFactory.getLogger(this.getClass());
+    // Logger identifier per instance
+    private final String randomIdString = RandomStringUtils.randomAlphanumeric(5);
+
+    private final ObjectWriter objectWriter = JsonUtil.getObjectMapperInstance().writer();
+
+    public static TSPointsProtoCursorsResponseParser.Builder builder() {
+        return new AutoValue_TSPointsProtoCursorsResponseParser.Builder()
+                .setRequest(Request.create());
+    }
+
+    public abstract TSPointsProtoCursorsResponseParser.Builder toBuilder();
+
+    public abstract Request getRequest();
+
+    public TSPointsProtoCursorsResponseParser withRequest(Request parameters) {
+        Preconditions.checkNotNull(parameters, "Request parameters cannot be null");
+        return toBuilder().setRequest(parameters).build();
+    }
+
+    /**
+     * Extracts the nextCursor for the next iteration of timestamp points.
+     *
+     * The cursor is a json object with each TS *externalId* (or id, if no externalId exists) mapped to the
+     * nextCursor value.
+     *
+     * @param payload The response body
+     * @return
+     * @throws Exception
+     */
+    public Optional<String> extractNextCursor(byte[] payload) throws Exception {
+        final String loggingPrefix = "Extracting next cursor [" + randomIdString + "] -";
+
+        LOG.debug(loggingPrefix + "Start extracting next cursor from TS data points payload.");
+        LOG.debug(loggingPrefix + "start parsing binary payload.");
+        DataPointListResponse response = DataPointListResponse.parseFrom(payload);
+        LOG.debug(loggingPrefix + "done parsing binary payload.");
+        List<DataPointListItem> responseItems = response.getItemsList();
+
+        if (responseItems.isEmpty()) {
+            // No items to parse, so no cursor
+            LOG.debug(loggingPrefix + "Could not find any TS list items in the response payload.");
+            return Optional.empty();
+        }
+        LOG.debug(loggingPrefix + "Found {} TS list response items in the response payload", responseItems.size());
+        // Adjust the limit based on the number of TS in the request
+        int effectiveLimit = TSIterationUtilities.calculateLimit(
+                (Integer) getRequest().getRequestParameters().getOrDefault("limit", DEFAULT_PARAMETER_LIMIT),
+                responseItems.size());
+
+        List<Map<String, Object>> cursorList = new ArrayList<>();
+        LOG.debug(loggingPrefix + "start iterating over all TS list response items. Effective limit set to {}", effectiveLimit);
+        for (DataPointListItem item : responseItems) {
+            Map<String, Object> cursorItem = new HashMap<>();
+            cursorItem.put("externalId", item.getExternalId());
+            cursorItem.put("id", item.getId());
+
+            OptionalLong nextTimestamp = getNextTimestampForTs(item, effectiveLimit);
+            if (nextTimestamp.isPresent()) {
+                cursorItem.put("timestamp", nextTimestamp.getAsLong());
+                cursorList.add(cursorItem);
+            }
+        }
+
+        if (cursorList.isEmpty()) {
+            // we have gotten all points, return that there is no nextCursor
+            LOG.debug(loggingPrefix + "All TS in payload have completed their download. No next cursor.");
+            return Optional.empty();
+        }
+        String cursorString = objectWriter.writeValueAsString(cursorList);
+        LOG.debug(loggingPrefix + "Cursor: \r\n {}", cursorString);
+        return Optional.of(cursorString);
+    }
+
+
+    /**
+     * Extract the results items from a response body.
+     *
+     * @param payload The reponse body
+     * @return
+     * @throws Exception
+     */
+    public ImmutableList<DataPointListItem> extractItems(byte[] payload) throws Exception {
+        final String loggingPrefix = "Extract TS items from proto payload [" + randomIdString + "] -";
+        LOG.debug(loggingPrefix + "Extracting items from TS data points proto payload.");
+        DataPointListResponse response = DataPointListResponse.parseFrom(payload);
+        List<DataPointListItem> tempList = response.getItemsList();
+        LOG.debug(loggingPrefix + "Extracting items - done parsing binary payload. Received {} TS list items", tempList.size());
+
+        if (tempList.isEmpty()) {
+            LOG.info(loggingPrefix + "No items found in the results payload.");
+        }
+
+        return ImmutableList.<DataPointListItem>copyOf(tempList);
+    }
+
+    /**
+     * Extracts the next expected timestamp for a list of timeseries points. This method is used to help iterate a
+     * timeseries query by producing the _startTime_ parameter of the next iteration/query.
+     *
+     * Both raw datapoints and aggregates are supported, but *includeOutsidePoints* are not supported.
+     *
+     * If the current payload/list of datapoints represents the final set of the iteration, this method will
+     * return an empty Optional.
+     *
+     * @param datapoints The timeseries to analyze
+     * @param limit The limit setting in the request
+     * @return The start timestamp for the next iteration, or an empty optional if this represents the final payload.
+     * @throws Exception
+     */
+    private OptionalLong getNextTimestampForTs(DataPointListItem datapoints, int limit) throws Exception {
+        final String loggingPrefix = "Get cursor for TS [" + randomIdString + "] -";
+        List<Long> timestamps = new ArrayList<>(10000);
+
+        LOG.debug(loggingPrefix + "extracting the list of timestamps from the TS.");
+        if (datapoints.hasNumericDatapoints()) {
+            List<NumericDatapoint> points = datapoints.getNumericDatapoints().getDatapointsList();
+            for (NumericDatapoint point : points) {
+                timestamps.add(point.getTimestamp());
+            }
+        } else if (datapoints.hasStringDatapoints()) {
+            List<StringDatapoint> points = datapoints.getStringDatapoints().getDatapointsList();
+            for (StringDatapoint point : points) {
+                timestamps.add(point.getTimestamp());
+            }
+        } else if (datapoints.hasAggregateDatapoints()) {
+            List<AggregateDatapoint> points = datapoints.getAggregateDatapoints().getDatapointsList();
+            for (AggregateDatapoint point : points) {
+                timestamps.add(point.getTimestamp());
+            }
+        }
+
+        // First check the length of the response to see if we received *limit* number of points.
+        // If we received less than *limit*, there are no more TS points to iterate over.
+        LOG.debug(loggingPrefix + "Effective limit parameter for the request: {}.", limit);
+        LOG.debug(loggingPrefix + "Number of TS points in the response: {}.", timestamps.size());
+        if (timestamps.size() < limit) {
+            return OptionalLong.empty();
+        }
+
+        // We may have more datapoints to fetch--let's investigate further.
+        LOG.debug(loggingPrefix + "Limit parameter and datapoints size are equal.");
+        // get the time of the last datapoint
+        long lastTimestamp = timestamps.get(timestamps.size() - 1);
+        LOG.debug(loggingPrefix + "Last datapoint timestamp: {}.", lastTimestamp);
+        long endTimestamp = Instant.now().toEpochMilli();
+        // check if we have an end time (otherwise it was now)
+        LOG.debug(loggingPrefix + "Check request for end time from attribute {}: [{}]",
+                END_KEY,
+                getRequest().getRequestParameters().get(END_KEY));
+        Optional<Long> requestEndTime = TSIterationUtilities.getEndAsMillis(getRequest());
+        if (requestEndTime.isPresent()) {
+            endTimestamp = requestEndTime.get();
+        }
+
+        // check that the latest point is not past the end time
+        if (lastTimestamp + 1 >= endTimestamp) {
+            LOG.debug(loggingPrefix + "Last timestamp > end key. No next cursor.");
+            // we have gotten all points, return that there is no nextCursor
+            return OptionalLong.empty();
+        }
+
+        // we are missing datapoints, return the next expected Timestamp
+        LOG.debug(loggingPrefix + "Need to fetch more datapoints. Building next cursor.");
+        long nextDelta = 1; // the default delta for raw datapoints
+
+        // Check if this is an aggregation
+        Optional<Duration> aggGranularity = TSIterationUtilities.getAggregateGranularityDuration(getRequest());
+        if (aggGranularity.isPresent()) {
+            LOG.debug(loggingPrefix + "Request is an aggregation request: {}",
+                    getRequest().getRequestParameters().get(GRANULARITY_KEY));
+            nextDelta = aggGranularity.get().toMillis();
+        }
+
+        // check that the new timestamp (cursor) point is not past the end time
+        if (lastTimestamp + nextDelta > endTimestamp) {
+            LOG.debug(loggingPrefix + "New timestamp > end key. No next cursor.");
+            // we have gotten all points, return that there is no nextCursor
+            return OptionalLong.empty();
+        }
+
+        return OptionalLong.of(lastTimestamp + nextDelta);
+    }
+
+
+    @AutoValue.Builder
+    public abstract static class Builder {
+        public abstract TSPointsProtoCursorsResponseParser.Builder setRequest(Request value);
+
+        public abstract TSPointsProtoCursorsResponseParser build();
+    }
+}

--- a/src/main/java/com/cognite/client/servicesV1/response/TSPointsProtoCursorsResponseParser.java
+++ b/src/main/java/com/cognite/client/servicesV1/response/TSPointsProtoCursorsResponseParser.java
@@ -18,9 +18,7 @@ package com.cognite.client.servicesV1.response;
 
 import com.cognite.client.Request;
 import com.cognite.client.servicesV1.util.JsonUtil;
-import com.cognite.client.servicesV1.util.TSIterationUtilities;
 import com.cognite.v1.timeseries.proto.*;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Preconditions;
@@ -29,16 +27,10 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.time.Duration;
-import java.time.Instant;
 import java.util.*;
 
 @AutoValue
 public abstract class TSPointsProtoCursorsResponseParser implements ResponseParser<DataPointListItem> {
-    private static final int DEFAULT_PARAMETER_LIMIT = 10000;
-
-    private static final String END_KEY = "end";
-    private static final String GRANULARITY_KEY = "granularity";
 
     private final Logger LOG = LoggerFactory.getLogger(this.getClass());
     // Logger identifier per instance
@@ -75,9 +67,9 @@ public abstract class TSPointsProtoCursorsResponseParser implements ResponsePars
 
         LOG.debug(loggingPrefix + "Start extracting next cursor from TS data points payload.");
         LOG.debug(loggingPrefix + "start parsing binary payload.");
-        DataPointListResponse response = DataPointListResponse.parseFrom(payload);
+        DataPointListResponseAlpha response = DataPointListResponseAlpha.parseFrom(payload);
         LOG.debug(loggingPrefix + "done parsing binary payload.");
-        List<DataPointListItem> responseItems = response.getItemsList();
+        List<DataPointListItemAlpha> responseItems = response.getItemsList();
 
         if (responseItems.isEmpty()) {
             // No items to parse, so no cursor
@@ -85,21 +77,16 @@ public abstract class TSPointsProtoCursorsResponseParser implements ResponsePars
             return Optional.empty();
         }
         LOG.debug(loggingPrefix + "Found {} TS list response items in the response payload", responseItems.size());
-        // Adjust the limit based on the number of TS in the request
-        int effectiveLimit = TSIterationUtilities.calculateLimit(
-                (Integer) getRequest().getRequestParameters().getOrDefault("limit", DEFAULT_PARAMETER_LIMIT),
-                responseItems.size());
 
         List<Map<String, Object>> cursorList = new ArrayList<>();
-        LOG.debug(loggingPrefix + "start iterating over all TS list response items. Effective limit set to {}", effectiveLimit);
-        for (DataPointListItem item : responseItems) {
+        LOG.debug(loggingPrefix + "start iterating over all TS list response items.");
+        for (DataPointListItemAlpha item : responseItems) {
             Map<String, Object> cursorItem = new HashMap<>();
             cursorItem.put("externalId", item.getExternalId());
             cursorItem.put("id", item.getId());
 
-            OptionalLong nextTimestamp = getNextTimestampForTs(item, effectiveLimit);
-            if (nextTimestamp.isPresent()) {
-                cursorItem.put("timestamp", nextTimestamp.getAsLong());
+            if (!item.getNextCursor().isBlank()) {
+                cursorItem.put("nextCursor", item.getNextCursor());
                 cursorList.add(cursorItem);
             }
         }
@@ -135,95 +122,6 @@ public abstract class TSPointsProtoCursorsResponseParser implements ResponsePars
 
         return ImmutableList.<DataPointListItem>copyOf(tempList);
     }
-
-    /**
-     * Extracts the next expected timestamp for a list of timeseries points. This method is used to help iterate a
-     * timeseries query by producing the _startTime_ parameter of the next iteration/query.
-     *
-     * Both raw datapoints and aggregates are supported, but *includeOutsidePoints* are not supported.
-     *
-     * If the current payload/list of datapoints represents the final set of the iteration, this method will
-     * return an empty Optional.
-     *
-     * @param datapoints The timeseries to analyze
-     * @param limit The limit setting in the request
-     * @return The start timestamp for the next iteration, or an empty optional if this represents the final payload.
-     * @throws Exception
-     */
-    private OptionalLong getNextTimestampForTs(DataPointListItem datapoints, int limit) throws Exception {
-        final String loggingPrefix = "Get cursor for TS [" + randomIdString + "] -";
-        List<Long> timestamps = new ArrayList<>(10000);
-
-        LOG.debug(loggingPrefix + "extracting the list of timestamps from the TS.");
-        if (datapoints.hasNumericDatapoints()) {
-            List<NumericDatapoint> points = datapoints.getNumericDatapoints().getDatapointsList();
-            for (NumericDatapoint point : points) {
-                timestamps.add(point.getTimestamp());
-            }
-        } else if (datapoints.hasStringDatapoints()) {
-            List<StringDatapoint> points = datapoints.getStringDatapoints().getDatapointsList();
-            for (StringDatapoint point : points) {
-                timestamps.add(point.getTimestamp());
-            }
-        } else if (datapoints.hasAggregateDatapoints()) {
-            List<AggregateDatapoint> points = datapoints.getAggregateDatapoints().getDatapointsList();
-            for (AggregateDatapoint point : points) {
-                timestamps.add(point.getTimestamp());
-            }
-        }
-
-        // First check the length of the response to see if we received *limit* number of points.
-        // If we received less than *limit*, there are no more TS points to iterate over.
-        LOG.debug(loggingPrefix + "Effective limit parameter for the request: {}.", limit);
-        LOG.debug(loggingPrefix + "Number of TS points in the response: {}.", timestamps.size());
-        if (timestamps.size() < limit) {
-            return OptionalLong.empty();
-        }
-
-        // We may have more datapoints to fetch--let's investigate further.
-        LOG.debug(loggingPrefix + "Limit parameter and datapoints size are equal.");
-        // get the time of the last datapoint
-        long lastTimestamp = timestamps.get(timestamps.size() - 1);
-        LOG.debug(loggingPrefix + "Last datapoint timestamp: {}.", lastTimestamp);
-        long endTimestamp = Instant.now().toEpochMilli();
-        // check if we have an end time (otherwise it was now)
-        LOG.debug(loggingPrefix + "Check request for end time from attribute {}: [{}]",
-                END_KEY,
-                getRequest().getRequestParameters().get(END_KEY));
-        Optional<Long> requestEndTime = TSIterationUtilities.getEndAsMillis(getRequest());
-        if (requestEndTime.isPresent()) {
-            endTimestamp = requestEndTime.get();
-        }
-
-        // check that the latest point is not past the end time
-        if (lastTimestamp + 1 >= endTimestamp) {
-            LOG.debug(loggingPrefix + "Last timestamp > end key. No next cursor.");
-            // we have gotten all points, return that there is no nextCursor
-            return OptionalLong.empty();
-        }
-
-        // we are missing datapoints, return the next expected Timestamp
-        LOG.debug(loggingPrefix + "Need to fetch more datapoints. Building next cursor.");
-        long nextDelta = 1; // the default delta for raw datapoints
-
-        // Check if this is an aggregation
-        Optional<Duration> aggGranularity = TSIterationUtilities.getAggregateGranularityDuration(getRequest());
-        if (aggGranularity.isPresent()) {
-            LOG.debug(loggingPrefix + "Request is an aggregation request: {}",
-                    getRequest().getRequestParameters().get(GRANULARITY_KEY));
-            nextDelta = aggGranularity.get().toMillis();
-        }
-
-        // check that the new timestamp (cursor) point is not past the end time
-        if (lastTimestamp + nextDelta > endTimestamp) {
-            LOG.debug(loggingPrefix + "New timestamp > end key. No next cursor.");
-            // we have gotten all points, return that there is no nextCursor
-            return OptionalLong.empty();
-        }
-
-        return OptionalLong.of(lastTimestamp + nextDelta);
-    }
-
 
     @AutoValue.Builder
     public abstract static class Builder {

--- a/src/main/java/com/cognite/client/servicesV1/response/TSPointsResponseParser.java
+++ b/src/main/java/com/cognite/client/servicesV1/response/TSPointsResponseParser.java
@@ -17,23 +17,18 @@
 package com.cognite.client.servicesV1.response;
 
 import com.cognite.client.Request;
-import com.cognite.client.servicesV1.util.DurationParser;
+import com.cognite.client.servicesV1.util.JsonUtil;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectWriter;
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Preconditions;
 
 import java.io.IOException;
-import java.time.Instant;
-import java.util.Optional;
+import java.util.*;
 
 @AutoValue
 public abstract class TSPointsResponseParser extends DefaultResponseParser {
-    private static final int DEFAULT_PARAMETER_LIMIT = 100;
-
-    private static final String END_KEY = "end";
-    private static final String GRANULARITY_KEY = "granularity";
-
-    private final DurationParser durationParser = DurationParser.builder().build();
+    private static final ObjectWriter objectWriter = JsonUtil.getObjectMapperInstance().writer();
 
     public static TSPointsResponseParser.Builder builder() {
         return new com.cognite.client.servicesV1.response.AutoValue_TSPointsResponseParser.Builder()
@@ -61,86 +56,31 @@ public abstract class TSPointsResponseParser extends DefaultResponseParser {
     public Optional<String> extractNextCursor(String json) throws Exception {
         LOG.info("Extracting next cursor from TS datapoints payload.");
 
-        JsonNode dataitems = objectMapper.readTree(json).path("items");
+        List<Map<String, Object>> cursorList = new ArrayList<>();
+        JsonNode dataitems = JsonUtil.getObjectMapperInstance().readTree(json).path("items");
         if (dataitems.isArray()) {
-            LOG.debug("Extracting next cursor. Found items in Json array.");
-            JsonNode datapoints = dataitems.get(0).path("datapoints");
-            if (datapoints.isArray()) {
-                LOG.debug("Extracting next cursor. Found datapoints in items Json array.");
-                // first check the length of the json response to see if we received *limit* number of points
-                final int limit = (Integer) getRequest().getRequestParameters()
-                                .getOrDefault("limit", DEFAULT_PARAMETER_LIMIT);
-                LOG.debug("Extracting next cursor. Limit parameter in request: {}.", limit);
-                if (datapoints.size() >= limit) {
-                    LOG.debug("Extracting next cursor. Limit parameter and datapoints size are equal.");
-                    // get the time of the last datapoint
-                    JsonNode lastPoint = datapoints.get(datapoints.size() - 1);
-                    long lastTimestamp = lastPoint.get("timestamp").longValue();
-                    LOG.debug("Extracting next cursor. Last datapoint timestamp: {}.", lastTimestamp);
-                    long endTimestamp = Instant.now().toEpochMilli();
-                    // check if we have an end time (otherwise it was now)
-                    if (getRequest().getRequestParameters().containsKey(END_KEY)) {
-                        LOG.debug("Extracting next cursor. Request contains end key: {}",
-                                getRequest().getRequestParameters().containsKey(END_KEY));
-
-                        // if end is String, we need to parse it
-                        if (getRequest().getRequestParameters().get(END_KEY) instanceof String) {
-                            LOG.debug("Extracting next cursor. Trying to parse end key");
-                            endTimestamp = System.currentTimeMillis() - durationParser
-                                    .parseDuration((String) getRequest().getRequestParameters().get(END_KEY))
-                                    .toMillis();
-
-                        } else if (getRequest().getRequestParameters().get(END_KEY) instanceof Number) {
-                            LOG.debug("Extracting next cursor. End key matched epoch timestamp");
-                            endTimestamp = (Long) getRequest().getRequestParameters().get(END_KEY);
-                        } else {
-                            // no compatible type.
-                            LOG.error("Parameter end is not a compatible type: "
-                                    + getRequest().getRequestParameters().get(END_KEY).getClass().getCanonicalName());
-                            throw new Exception("Parameter end is not a compatible type: "
-                                    + getRequest().getRequestParameters().get(END_KEY).getClass().getCanonicalName());
-                        }
-                    }
-                    // if we do have an end time, check that the latest point is not past it
-                    if (lastTimestamp + 1 >= endTimestamp) {
-                        LOG.debug("Extracting next cursor. Last timestamp > end key. No next cursor.");
-                        // we have gotten all points, return that there is no nextCursor
-                        return Optional.empty();
-                    }
-
-                    // we are missing datapoints, return the next expected Timestamp
-                    LOG.debug("Extracting next cursor. Need to fetch more datapoints. Building next cursor.");
-                    long nextDelta = 1;
-
-                    // Check if this is an aggregation
-                    if (getRequest().getRequestParameters().containsKey(GRANULARITY_KEY)) {
-                        LOG.debug("Extracting next cursor. Request is an aggregation request: {}",
-                                getRequest().getRequestParameters().get(GRANULARITY_KEY));
-                        // Parse the granularity specification
-                        if (getRequest().getRequestParameters().get(GRANULARITY_KEY) instanceof String) {
-                            LOG.debug("Extracting next cursor. Trying to parse the granularity key.");
-                            String granularityString = (String) getRequest().getRequestParameters().get(GRANULARITY_KEY);
-                            nextDelta = durationParser.parseDuration(granularityString).toMillis();
-
-                        } else {
-                            // no compatible type.
-                            LOG.error("Parameter " + GRANULARITY_KEY + " is not a compatible type: "
-                                    + getRequest().getRequestParameters().get(GRANULARITY_KEY)
-                                            .getClass().getCanonicalName());
-                            throw new Exception("Parameter " + GRANULARITY_KEY + " is not a compatible type: "
-                                    + getRequest().getRequestParameters().get(GRANULARITY_KEY)
-                                    .getClass().getCanonicalName());
-                        }
-                    }
-
-                    return Optional.of(Long.toString(lastTimestamp + nextDelta));
+            LOG.debug("Start iterating over all TS list response items.");
+            for (JsonNode item : dataitems) {
+                if (item.path("nextCursor").isTextual()) {
+                    Map<String, Object> cursorItem = new HashMap<>();
+                    cursorItem.put("nextCursor", item.path("nextCursor").textValue());
+                    if (item.path("externalId").isTextual())
+                        cursorItem.put("externalId", item.path("externalId").textValue());
+                    if (item.path("id").isIntegralNumber())
+                        cursorItem.put("id", item.path("id").longValue());
+                    cursorList.add(cursorItem);
                 }
             }
         }
-        // we have gotten all points, return that there is no nextCursor
-        LOG.info("Next cursor not found in Json payload: \r\n" + json
-                .substring(0, Math.min(MAX_LENGTH_JSON_LOG, json.length())));
-        return Optional.empty();
+
+        if (cursorList.isEmpty()) {
+            // we have gotten all points, return that there is no nextCursor
+            LOG.debug("All TS in payload have completed their download. No next cursor.");
+            return Optional.empty();
+        }
+        String cursorString = objectWriter.writeValueAsString(cursorList);
+        LOG.debug("Cursor: \r\n {}", cursorString);
+        return Optional.of(cursorString);
     }
 
     @AutoValue.Builder

--- a/src/main/proto/cognite/v1/timeseries/proto/data_point_list_response_alpha.proto
+++ b/src/main/proto/cognite/v1/timeseries/proto/data_point_list_response_alpha.proto
@@ -1,0 +1,26 @@
+syntax = "proto3";
+
+package com.cognite.v1.timeseries.proto;
+
+import "data_points.proto";
+
+option java_multiple_files = true;
+
+message DataPointListItemAlpha {
+    int64 id = 1;
+    string externalId = 2;
+    bool isString = 6;
+    bool isStep = 7;
+    string unit = 8;
+    string nextCursor = 9;
+
+    oneof datapointType {
+        NumericDatapoints numericDatapoints = 3;
+        StringDatapoints stringDatapoints = 4;
+        AggregateDatapoints aggregateDatapoints = 5;
+    }
+}
+
+message DataPointListResponseAlpha {
+    repeated DataPointListItemAlpha items = 1;
+}

--- a/src/test/java/com/cognite/client/TimeseriesIntegrationTest.java
+++ b/src/test/java/com/cognite/client/TimeseriesIntegrationTest.java
@@ -82,8 +82,8 @@ class TimeseriesIntegrationTest {
     @Tag("remoteCDP")
     void writeReadAndDeleteTimeseriesDataPoints() throws Exception {
         Instant startInstant = Instant.now();
-        final int noTsHeaders = 35;
-        final int noTsPoints = 517893;
+        final int noTsHeaders = 5;
+        final int noTsPoints = 1517893;
         final double tsPointsFrequency = 1d;
         ClientConfig config = ClientConfig.create()
                 .withNoWorkers(4)

--- a/src/test/java/com/cognite/client/TimeseriesIntegrationTest.java
+++ b/src/test/java/com/cognite/client/TimeseriesIntegrationTest.java
@@ -46,7 +46,7 @@ class TimeseriesIntegrationTest {
                 Duration.between(startInstant, Instant.now()));
 
         LOG.info(loggingPrefix + "Start upserting timeseries.");
-        List<TimeseriesMetadata> upsertTimeseriesList = DataGenerator.generateTsHeaderObjects(9800);
+        List<TimeseriesMetadata> upsertTimeseriesList = DataGenerator.generateTsHeaderObjects(7800);
         client.timeseries().upsert(upsertTimeseriesList);
         LOG.info(loggingPrefix + "Finished upserting timeseries. Duration: {}",
                 Duration.between(startInstant, Instant.now()));

--- a/src/test/java/com/cognite/client/TimeseriesIntegrationTest.java
+++ b/src/test/java/com/cognite/client/TimeseriesIntegrationTest.java
@@ -82,7 +82,7 @@ class TimeseriesIntegrationTest {
     @Tag("remoteCDP")
     void writeReadAndDeleteTimeseriesDataPoints() throws Exception {
         Instant startInstant = Instant.now();
-        final int noTsHeaders = 15;
+        final int noTsHeaders = 35;
         final int noTsPoints = 517893;
         final double tsPointsFrequency = 1d;
         ClientConfig config = ClientConfig.create()
@@ -123,14 +123,14 @@ class TimeseriesIntegrationTest {
                 Duration.between(startInstant, Instant.now()));
         LOG.info(loggingPrefix + "----------------------------------------------------------------------");
 
-        Thread.sleep(5000); // wait for eventual consistency
+        Thread.sleep(10000); // wait for eventual consistency
 
         LOG.info(loggingPrefix + "Start reading timeseries.");
         List<TimeseriesMetadata> listTimeseriesResults = new ArrayList<>();
         client.timeseries()
                 .list(Request.create()
                         .withFilterMetadataParameter("source", DataGenerator.sourceValue))
-                .forEachRemaining(timeseries -> listTimeseriesResults.addAll(timeseries));
+                .forEachRemaining(listTimeseriesResults::addAll);
         LOG.info(loggingPrefix + "Finished reading timeseries. Duration: {}",
                 Duration.between(startInstant, Instant.now()));
         LOG.info(loggingPrefix + "----------------------------------------------------------------------");

--- a/src/test/java/com/cognite/client/TimeseriesIntegrationTest.java
+++ b/src/test/java/com/cognite/client/TimeseriesIntegrationTest.java
@@ -123,8 +123,6 @@ class TimeseriesIntegrationTest {
                 Duration.between(startInstant, Instant.now()));
         LOG.info(loggingPrefix + "----------------------------------------------------------------------");
 
-        Thread.sleep(10000); // wait for eventual consistency
-
         LOG.info(loggingPrefix + "Start reading timeseries.");
         List<TimeseriesMetadata> listTimeseriesResults = new ArrayList<>();
         client.timeseries()

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -19,9 +19,9 @@
     </appender>
 
     <logger name="com.cognite.client" level="INFO"/>
-    <!--logger name="com.cognite.client.ApiBase" level="DEBUG"/-->
-    <!--logger name="com.cognite.client.servicesV1.executor" level="DEBUG"/-->
-    <!--logger name="com.cognite.client.RawRows" level="INFO"/-->
+    <logger name="com.cognite.client.ApiBase" level="INFO"/>
+    <logger name="com.cognite.client.servicesV1.executor" level="DEBUG"/>
+    <logger name="com.cognite.client.DataPoints" level="DEBUG"/>
 
     <root level="info">
         <appender-ref ref="STDOUT" />

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -20,8 +20,8 @@
 
     <logger name="com.cognite.client" level="INFO"/>
     <logger name="com.cognite.client.ApiBase" level="INFO"/>
-    <logger name="com.cognite.client.servicesV1.executor" level="DEBUG"/>
-    <logger name="com.cognite.client.DataPoints" level="DEBUG"/>
+    <logger name="com.cognite.client.servicesV1.executor" level="INFO"/>
+    <logger name="com.cognite.client.DataPoints" level="INFO"/>
 
     <root level="info">
         <appender-ref ref="STDOUT" />


### PR DESCRIPTION
- Bump dependencies
- Add requestProvider and ResponseParser using the new cursor to iterate TS data points (behind the alpha flag). This is currently activated in the default code path for listing data points. 
- Refactor the split/parallelization algorithm for listing data points. New algorithm favors splitting by TS item over splitting by time window.

Before SDK release, we'll sync with Timelords and verify GA for the nextCursor in the API so we can remove the alpha flag.