### PR TITLE
Release 1.18.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ information ([./docs/index.md](./docs/index.md)).
 <dependency>    
     <groupId>com.cognite</groupId>
     <artifactId>cdf-sdk-java</artifactId>
-    <version>1.17.0</version>
+    <version>1.18.0</version>
 </dependency>
 ```
     

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.cognite</groupId>
     <artifactId>cdf-sdk-java</artifactId>
-    <version>1.18.0-SNAPSHOT</version>
+    <version>1.18.0</version>
     <licenses>
         <license>
             <name>Apache 2</name>
@@ -43,7 +43,7 @@
 
         <auto.version>1.9</auto.version>
         <nimbusds.version>9.43.1</nimbusds.version>
-        <awss3.version>1.12.266</awss3.version>
+        <awss3.version>1.12.315</awss3.version>
         <jgrapht.version>1.5.1</jgrapht.version>
         <okhttp3.version>4.10.0</okhttp3.version>
         <jackson.version>2.13.4</jackson.version>

--- a/releases.md
+++ b/releases.md
@@ -17,13 +17,19 @@ Changes are grouped as follows:
 
 ### Short term
 
-## [1.18.0-SNAPSHOT]
+## [1.18.0] 2022-10-15
 
 ### Added
 
-### Changed
+- Improved performance when reading time series `data point`. When reading 2 - 100 time series in a single request you should see up to 10x improvement in throughput.
+- A new cursor-based iteration of time series `data points`. This is pre-release functionality which can be enabled by setting a feature flag in the `ClientConfig`. 
+```java
+ClientConfig config = ClientConfig.create()
+        .withExperimental(FeatureFlag.create()
+                .enableDataPointsCursor(true));     // Enable the new cursor-based iterator
 
-- `Data points` now uses the new cursor-based iteration offered by the API.
+CogniteClient.withClientConfig(config);             // Pass the config to the client
+```
 
 ### Fixed
 

--- a/src/main/java/com/cognite/client/config/ClientConfig.java
+++ b/src/main/java/com/cognite/client/config/ClientConfig.java
@@ -244,7 +244,7 @@ public abstract class ClientConfig implements Serializable {
 
     @AutoValue
     public static abstract class FeatureFlag implements Serializable {
-        private static final boolean DEFAULT_ENABLE_DATA_POINTS_CURSOR = true;
+        private static final boolean DEFAULT_ENABLE_DATA_POINTS_CURSOR = false;
         private static Builder builder() {
             return new AutoValue_ClientConfig_FeatureFlag.Builder()
                     .setDataPointsCursorEnabled(DEFAULT_ENABLE_DATA_POINTS_CURSOR);


### PR DESCRIPTION
Release 1.18.0

- Set the new cursor-based iterator (which is in api alpha) behind a feature flag which must be explicitly enabled.