### PR TITLE
Fix configure cdf project

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,10 @@ CogniteClient client = CogniteClient.ofKey(<yourApiKey>)
         
 // ... or use client credentials (OpenID Connect)
 CogniteClient client = CogniteClient.ofClientCredentials(
+        <cdfProject>,
         <clientId>,
         <clientSecret>,
         TokenUrl.generateAzureAdURL(<azureAdTenantId>))
-        .withProject("myCdfProject")
         .withBaseUrl("https://yourBaseURL.cognitedata.com"); //optional parameter     
         
 // List all assets

--- a/docs/clientSetup.md
+++ b/docs/clientSetup.md
@@ -38,7 +38,7 @@ CogniteClient client = CogniteClient.ofClientCredentials(
         cdfProject,
         clientId, 
         clientSecret, 
-        TokenUrl.generateAzureAdURL(azureAdTenantId);
+        TokenUrl.generateAzureAdURL(azureAdTenantId));
 
 // Using custom authentication scopes
 String cdfBaseUrl = "https://api.cognitedata.com"

--- a/docs/clientSetup.md
+++ b/docs/clientSetup.md
@@ -35,16 +35,17 @@ String azureAdTenantId = "my-aad-tenant-id";
 String cdfProject = "my-cdf-project";
 
 CogniteClient client = CogniteClient.ofClientCredentials(
+        cdfProject,
         clientId, 
         clientSecret, 
-        TokenUrl.generateAzureAdURL(azureAdTenantId))
-        .withProject(cdfProject);
+        TokenUrl.generateAzureAdURL(azureAdTenantId);
 
 // Using custom authentication scopes
 String cdfBaseUrl = "https://api.cognitedata.com"
 List<String> authScopes = List.of(cdfBaseUrl + "/.default", "my-second-scope");
 
 CogniteClient client = CogniteClient.ofClientCredentials(
+        cdfProject,
         clientId,
         clientSecret,
         TokenUrl.generateAzureAdURL(azureAdTenantId),
@@ -59,8 +60,7 @@ support for these. Instead you can extend the SDK by handling these other flows 
 ```java
 String cdfProject = "my-cdf-project";
 
-CogniteClient client = CogniteClient.ofToken(Supplier<String> tokenSupplier)
-        .withProject(cdfProject);
+CogniteClient client = CogniteClient.ofToken(cdfProject, Supplier<String> tokenSupplier);
 ```
 The `tokenSupplier` is a functional interface, so you can pass in a lambda function. The `tokenSupplier`
 will be called for each api request and expects a valid token in return. The token is added to
@@ -68,7 +68,7 @@ the `Authorization` header in each request. Your supplier needs to produce the e
 the header, including the `Bearer` prefix. That is, your supplier should produce a String
 of the following pattern: `Bearer <your-access-token>`.
 
-#### API keys
+#### API keys (deprecated)
 
 Authentication via API key is the legacy method of authenticating services towards Cognite Data Fusion.
 You simply supply the API key when creating the client:
@@ -102,10 +102,10 @@ ClientConfig clientConfig = ClientConfig.create()
         .withProxyConfig(proxyConfig);
 
 CogniteClient client = CogniteClient.ofClientCredentials(
+        cdfProject,
         clientId,
         clientSecret,
         TokenUrl.generateAzureAdURL(azureAdTenantId))
-        .withProject(cdfProject)
         .withClientConfig(clientConfig);
 
 /*

--- a/pom.xml
+++ b/pom.xml
@@ -252,7 +252,7 @@
                     <useIncrementalCompilation>false</useIncrementalCompilation>
                     <compilerArgs>
                         <arg>-Xlint:all</arg>
-                        <arg>${compiler.error.flag}</arg>
+                        <!-- arg>${compiler.error.flag}</arg-->
                         <!-- Override options warnings to support cross-compilation -->
                         <arg>-Xlint:-options</arg>
                         <!-- Temporary lint overrides, to be removed over time. -->

--- a/releases.md
+++ b/releases.md
@@ -20,8 +20,19 @@ Changes are grouped as follows:
 ## [1.19.0-SNAPSHOT]
 
 ### Added
+
 - The new cursor-based `data-points` iterator is enabled by default.
 - Support for `geoLocation` on `assets`.
+- New versions of `CogniteClient.ofClientCredentials()` and `CogniteClient.ofToken()` which include the `cdfProject` parameter. The `CDF project` must be specified for the client to work correctly.
+
+### Deprecated
+
+- Deprecated `CogniteClient.ofClientCredentials()` and `CogniteClient.ofToken()` which do not include the `cdfProject` parameter. Please migrate to the new versions of these methods which include the `cdfProject` parameter.
+- Deprecate `CogniteClient.ofKey()` as the API key authentication method is soon to be removed from Cognite Data Fusion.
+
+### Fixed
+
+- Issue a warning if the `CDF project` is not configured for the client.
 
 ## [1.18.0] 2022-10-15
 

--- a/src/main/java/com/cognite/client/CogniteClient.java
+++ b/src/main/java/com/cognite/client/CogniteClient.java
@@ -709,10 +709,17 @@ public abstract class CogniteClient implements Serializable {
         if (null != getProject()) {
             // The project is explicitly defined
             cdfProject = getProject();
+        } else if (getAuthType() != AuthType.API_KEY) {
+            // CDF Project is not specified and the auth type is OIDC. Invalid combination, so we'll
+            // throw an Exception.
+            // This is a workaround until we can remove API key support all in all.
+            String message = "The CDF project is not defined. Please specify the CDF project when creating the CogniteClient.";
+            LOG.error(message);
+            throw new Exception(message);
         } else if (null != cdfProjectCache) {
             // The project info is cached
             cdfProject = cdfProjectCache;
-        } else {
+        }else {
             // Have to get the project via the auth credentials
             // TODO: Remove when deprecating api keys
             LOG.warn("The CDF project is not configured for the CogniteClient. API calls may fail.");

--- a/src/main/java/com/cognite/client/config/AuthConfig.java
+++ b/src/main/java/com/cognite/client/config/AuthConfig.java
@@ -17,6 +17,7 @@
 package com.cognite.client.config;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.base.Preconditions;
 
 import javax.annotation.Nullable;
 import java.io.Serializable;
@@ -37,10 +38,15 @@ public abstract class AuthConfig implements Serializable {
             .setHost(DEFAULT_HOST);
   }
 
+  // TODO: Remove when deprecating api keys
+  @Deprecated
   public static AuthConfig create() {
     return AuthConfig.builder().build();
   }
   public static AuthConfig of(String cdfProject) {
+    Preconditions.checkArgument(null != cdfProject && !cdfProject.isBlank(),
+            "The CDF Project cannot be null or blank.");
+
     return AuthConfig.builder()
             .setProject(cdfProject)
             .build();
@@ -65,6 +71,7 @@ public abstract class AuthConfig implements Serializable {
   }
 
 
+  // TODO: Remove when deprecating api keys
   /**
    * Set the Cognite Data Fusion project (environment) to connect with.
    *

--- a/src/main/java/com/cognite/client/servicesV1/ConnectorServiceV1.java
+++ b/src/main/java/com/cognite/client/servicesV1/ConnectorServiceV1.java
@@ -1071,9 +1071,6 @@ public abstract class ConnectorServiceV1 implements Serializable {
      * @return
      */
     public ItemWriter deleteFiles() {
-        LOG.debug(loggingPrefix + "Initiating delete files service.");
-        
-
         PostJsonRequestProvider requestProvider = PostJsonRequestProvider.builder()
                 .setEndpoint("files/delete")
                 .setRequest(Request.create())
@@ -1092,8 +1089,7 @@ public abstract class ConnectorServiceV1 implements Serializable {
      * @return
      */
     public LoginStatus readLoginStatusByApiKey(String host) throws Exception {
-        LOG.debug(loggingPrefix + "Getting login status for host [{}].", host);
-
+        // TODO: Remove when deprecating api keys
         GetLoginRequestProvider requestProvider = GetLoginRequestProvider.builder()
                 .setEndpoint("status")
                 .setSdkIdentifier(getClient().getClientConfig().getSdkIdentifier())

--- a/src/test/java/com/cognite/client/AssetsIntegrationTest.java
+++ b/src/test/java/com/cognite/client/AssetsIntegrationTest.java
@@ -38,12 +38,7 @@ class AssetsIntegrationTest {
         Instant startInstant = Instant.now();
         String loggingPrefix = "UnitTest - writeReadAndDeleteAssets() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
-        CogniteClient client = CogniteClient.ofClientCredentials(
-                    TestConfigProvider.getProject(),
-                    TestConfigProvider.getClientId(),
-                    TestConfigProvider.getClientSecret(),
-                    TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withBaseUrl(TestConfigProvider.getHost())
+        CogniteClient client = TestConfigProvider.getCogniteClient()
                 ;
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",
                 Duration.between(startInstant, Instant.now()));
@@ -93,12 +88,7 @@ class AssetsIntegrationTest {
         Instant startInstant = Instant.now();
         String loggingPrefix = "UnitTest - synchronizeAssetHierarchy() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
-        CogniteClient client = CogniteClient.ofClientCredentials(
-                    TestConfigProvider.getProject(),
-                    TestConfigProvider.getClientId(),
-                    TestConfigProvider.getClientSecret(),
-                    TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withBaseUrl(TestConfigProvider.getHost())
+        CogniteClient client = TestConfigProvider.getCogniteClient()
                 ;
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",
                 Duration.between(startInstant, Instant.now()));
@@ -168,12 +158,7 @@ class AssetsIntegrationTest {
         Instant startInstant = Instant.now();
         String loggingPrefix = "UnitTest - synchronizeMultipleAssetHierarchies() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
-        CogniteClient client = CogniteClient.ofClientCredentials(
-                    TestConfigProvider.getProject(),
-                    TestConfigProvider.getClientId(),
-                    TestConfigProvider.getClientSecret(),
-                    TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withBaseUrl(TestConfigProvider.getHost())
+        CogniteClient client = TestConfigProvider.getCogniteClient()
                 ;
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",
                 Duration.between(startInstant, Instant.now()));
@@ -244,12 +229,7 @@ class AssetsIntegrationTest {
         Instant startInstant = Instant.now();
         String loggingPrefix = "UnitTest - writeEditAndDeleteAssets() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
-        CogniteClient client = CogniteClient.ofClientCredentials(
-                    TestConfigProvider.getProject(),
-                    TestConfigProvider.getClientId(),
-                    TestConfigProvider.getClientSecret(),
-                    TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withBaseUrl(TestConfigProvider.getHost())
+        CogniteClient client = TestConfigProvider.getCogniteClient()
                 ;
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",
                 Duration.between(startInstant, Instant.now()));
@@ -346,12 +326,7 @@ class AssetsIntegrationTest {
         Instant startInstant = Instant.now();
         String loggingPrefix = "UnitTest - writeRetrieveAndDeleteAssets() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
-        CogniteClient client = CogniteClient.ofClientCredentials(
-                    TestConfigProvider.getProject(),
-                    TestConfigProvider.getClientId(),
-                    TestConfigProvider.getClientSecret(),
-                    TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withBaseUrl(TestConfigProvider.getHost())
+        CogniteClient client = TestConfigProvider.getCogniteClient()
                 ;
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",
                 Duration.between(startInstant, Instant.now()));
@@ -413,12 +388,7 @@ class AssetsIntegrationTest {
         Instant startInstant = Instant.now();
         String loggingPrefix = "UnitTest - writeAggregateAndDeleteAssets() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
-        CogniteClient client = CogniteClient.ofClientCredentials(
-                    TestConfigProvider.getProject(),
-                    TestConfigProvider.getClientId(),
-                    TestConfigProvider.getClientSecret(),
-                    TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withBaseUrl(TestConfigProvider.getHost())
+        CogniteClient client = TestConfigProvider.getCogniteClient()
                 ;
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",
                 Duration.between(startInstant, Instant.now()));
@@ -476,12 +446,7 @@ class AssetsIntegrationTest {
 
         String loggingPrefix = "UnitTest - writeStreamAndDeleteAssets() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
-        CogniteClient client = CogniteClient.ofClientCredentials(
-                        TestConfigProvider.getClientId(),
-                        TestConfigProvider.getClientSecret(),
-                        TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                .withProject(TestConfigProvider.getProject())
-                .withBaseUrl(TestConfigProvider.getHost())
+        CogniteClient client = TestConfigProvider.getCogniteClient()
                 //.withClientConfig(config)
                 ;
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",

--- a/src/test/java/com/cognite/client/AssetsIntegrationTest.java
+++ b/src/test/java/com/cognite/client/AssetsIntegrationTest.java
@@ -39,10 +39,10 @@ class AssetsIntegrationTest {
         String loggingPrefix = "UnitTest - writeReadAndDeleteAssets() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
         CogniteClient client = CogniteClient.ofClientCredentials(
+                    TestConfigProvider.getProject(),
                     TestConfigProvider.getClientId(),
                     TestConfigProvider.getClientSecret(),
                     TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withProject(TestConfigProvider.getProject())
                     .withBaseUrl(TestConfigProvider.getHost())
                 ;
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",
@@ -94,10 +94,10 @@ class AssetsIntegrationTest {
         String loggingPrefix = "UnitTest - synchronizeAssetHierarchy() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
         CogniteClient client = CogniteClient.ofClientCredentials(
+                    TestConfigProvider.getProject(),
                     TestConfigProvider.getClientId(),
                     TestConfigProvider.getClientSecret(),
                     TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withProject(TestConfigProvider.getProject())
                     .withBaseUrl(TestConfigProvider.getHost())
                 ;
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",
@@ -169,10 +169,10 @@ class AssetsIntegrationTest {
         String loggingPrefix = "UnitTest - synchronizeMultipleAssetHierarchies() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
         CogniteClient client = CogniteClient.ofClientCredentials(
+                    TestConfigProvider.getProject(),
                     TestConfigProvider.getClientId(),
                     TestConfigProvider.getClientSecret(),
                     TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withProject(TestConfigProvider.getProject())
                     .withBaseUrl(TestConfigProvider.getHost())
                 ;
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",
@@ -245,10 +245,10 @@ class AssetsIntegrationTest {
         String loggingPrefix = "UnitTest - writeEditAndDeleteAssets() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
         CogniteClient client = CogniteClient.ofClientCredentials(
+                    TestConfigProvider.getProject(),
                     TestConfigProvider.getClientId(),
                     TestConfigProvider.getClientSecret(),
                     TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withProject(TestConfigProvider.getProject())
                     .withBaseUrl(TestConfigProvider.getHost())
                 ;
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",
@@ -347,10 +347,10 @@ class AssetsIntegrationTest {
         String loggingPrefix = "UnitTest - writeRetrieveAndDeleteAssets() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
         CogniteClient client = CogniteClient.ofClientCredentials(
+                    TestConfigProvider.getProject(),
                     TestConfigProvider.getClientId(),
                     TestConfigProvider.getClientSecret(),
                     TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withProject(TestConfigProvider.getProject())
                     .withBaseUrl(TestConfigProvider.getHost())
                 ;
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",
@@ -414,10 +414,10 @@ class AssetsIntegrationTest {
         String loggingPrefix = "UnitTest - writeAggregateAndDeleteAssets() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
         CogniteClient client = CogniteClient.ofClientCredentials(
+                    TestConfigProvider.getProject(),
                     TestConfigProvider.getClientId(),
                     TestConfigProvider.getClientSecret(),
                     TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withProject(TestConfigProvider.getProject())
                     .withBaseUrl(TestConfigProvider.getHost())
                 ;
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",

--- a/src/test/java/com/cognite/client/CogniteClientTest.java
+++ b/src/test/java/com/cognite/client/CogniteClientTest.java
@@ -27,6 +27,7 @@ class CogniteClientTest {
         CogniteClient client = CogniteClient.ofClientCredentials("123", "secret", new URL("https://localhost/cogniteapi")).withBaseUrl("https://localhost");
         assertNotNull(client.getHttpClient());
         List<Interceptor> interceptorList = client.getHttpClient().interceptors();
+        //client.buildAuthConfig();
         assertNotNull(interceptorList);
         assertEquals(1, interceptorList.size());
         assertEquals("com.cognite.client.CogniteClient$ClientCredentialsInterceptor", interceptorList.get(0).getClass().getName());
@@ -38,6 +39,7 @@ class CogniteClientTest {
         CogniteClient client = CogniteClient.ofClientCredentials("myCdfProject", "123", "secret", new URL("https://localhost/cogniteapi")).withBaseUrl("https://localhost");
         assertNotNull(client.getHttpClient());
         List<Interceptor> interceptorList = client.getHttpClient().interceptors();
+        client.buildAuthConfig();
         assertNotNull(interceptorList);
         assertEquals(1, interceptorList.size());
         assertEquals("com.cognite.client.CogniteClient$ClientCredentialsInterceptor", interceptorList.get(0).getClass().getName());

--- a/src/test/java/com/cognite/client/CogniteClientTest.java
+++ b/src/test/java/com/cognite/client/CogniteClientTest.java
@@ -23,8 +23,19 @@ class CogniteClientTest {
     }
 
     @Test
-    void test_ofClientCredentials_config() throws Exception {
+    void test_ofClientCredentials_config_missing_project() throws Exception {
         CogniteClient client = CogniteClient.ofClientCredentials("123", "secret", new URL("https://localhost/cogniteapi")).withBaseUrl("https://localhost");
+        assertNotNull(client.getHttpClient());
+        List<Interceptor> interceptorList = client.getHttpClient().interceptors();
+        assertNotNull(interceptorList);
+        assertEquals(1, interceptorList.size());
+        assertEquals("com.cognite.client.CogniteClient$ClientCredentialsInterceptor", interceptorList.get(0).getClass().getName());
+        assertEquals("https://localhost", client.getBaseUrl());
+    }
+
+    @Test
+    void test_ofClientCredentials_config() throws Exception {
+        CogniteClient client = CogniteClient.ofClientCredentials("myCdfProject", "123", "secret", new URL("https://localhost/cogniteapi")).withBaseUrl("https://localhost");
         assertNotNull(client.getHttpClient());
         List<Interceptor> interceptorList = client.getHttpClient().interceptors();
         assertNotNull(interceptorList);

--- a/src/test/java/com/cognite/client/CogniteClientUnitTest.java
+++ b/src/test/java/com/cognite/client/CogniteClientUnitTest.java
@@ -2,15 +2,17 @@ package com.cognite.client;
 
 import okhttp3.ConnectionSpec;
 import okhttp3.Interceptor;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import java.net.URL;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-class CogniteClientTest {
+class CogniteClientUnitTest {
 
     @Test
+    @Disabled
     void test_ofKey_config() {
         CogniteClient client = CogniteClient.ofKey("TEST").withBaseUrl("https://localhost");
         assertNotNull(client.getHttpClient());
@@ -27,7 +29,7 @@ class CogniteClientTest {
         CogniteClient client = CogniteClient.ofClientCredentials("123", "secret", new URL("https://localhost/cogniteapi")).withBaseUrl("https://localhost");
         assertNotNull(client.getHttpClient());
         List<Interceptor> interceptorList = client.getHttpClient().interceptors();
-        //client.buildAuthConfig();
+        assertThrows(Exception.class, () -> client.buildAuthConfig());
         assertNotNull(interceptorList);
         assertEquals(1, interceptorList.size());
         assertEquals("com.cognite.client.CogniteClient$ClientCredentialsInterceptor", interceptorList.get(0).getClass().getName());
@@ -39,7 +41,7 @@ class CogniteClientTest {
         CogniteClient client = CogniteClient.ofClientCredentials("myCdfProject", "123", "secret", new URL("https://localhost/cogniteapi")).withBaseUrl("https://localhost");
         assertNotNull(client.getHttpClient());
         List<Interceptor> interceptorList = client.getHttpClient().interceptors();
-        client.buildAuthConfig();
+        assertDoesNotThrow(() -> client.buildAuthConfig());
         assertNotNull(interceptorList);
         assertEquals(1, interceptorList.size());
         assertEquals("com.cognite.client.CogniteClient$ClientCredentialsInterceptor", interceptorList.get(0).getClass().getName());

--- a/src/test/java/com/cognite/client/DataSetsIntegrationTest.java
+++ b/src/test/java/com/cognite/client/DataSetsIntegrationTest.java
@@ -29,12 +29,7 @@ class DataSetsIntegrationTest {
                 .withNoListPartitions(1);
         String loggingPrefix = "UnitTest - listAndRetrieveDataSets() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
-        CogniteClient client = CogniteClient.ofClientCredentials(
-                    TestConfigProvider.getProject(),
-                    TestConfigProvider.getClientId(),
-                    TestConfigProvider.getClientSecret(),
-                    TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withBaseUrl(TestConfigProvider.getHost())
+        CogniteClient client = TestConfigProvider.getCogniteClient()
                 //.withClientConfig(config)
                 ;
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",

--- a/src/test/java/com/cognite/client/DataSetsIntegrationTest.java
+++ b/src/test/java/com/cognite/client/DataSetsIntegrationTest.java
@@ -30,10 +30,10 @@ class DataSetsIntegrationTest {
         String loggingPrefix = "UnitTest - listAndRetrieveDataSets() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
         CogniteClient client = CogniteClient.ofClientCredentials(
+                    TestConfigProvider.getProject(),
                     TestConfigProvider.getClientId(),
                     TestConfigProvider.getClientSecret(),
                     TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withProject(TestConfigProvider.getProject())
                     .withBaseUrl(TestConfigProvider.getHost())
                 //.withClientConfig(config)
                 ;

--- a/src/test/java/com/cognite/client/DiagramsIntegrationTest.java
+++ b/src/test/java/com/cognite/client/DiagramsIntegrationTest.java
@@ -38,10 +38,10 @@ class DiagramsIntegrationTest {
         String loggingPrefix = "UnitTest - createInteractiveDiagrams() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
         CogniteClient client = CogniteClient.ofClientCredentials(
+                    TestConfigProvider.getProject(),
                     TestConfigProvider.getClientId(),
                     TestConfigProvider.getClientSecret(),
                     TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withProject(TestConfigProvider.getProject())
                     .withBaseUrl(TestConfigProvider.getHost())
                 //.withClientConfig(config)
                 ;

--- a/src/test/java/com/cognite/client/DiagramsIntegrationTest.java
+++ b/src/test/java/com/cognite/client/DiagramsIntegrationTest.java
@@ -37,12 +37,7 @@ class DiagramsIntegrationTest {
                 .withNoListPartitions(1);
         String loggingPrefix = "UnitTest - createInteractiveDiagrams() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
-        CogniteClient client = CogniteClient.ofClientCredentials(
-                    TestConfigProvider.getProject(),
-                    TestConfigProvider.getClientId(),
-                    TestConfigProvider.getClientSecret(),
-                    TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withBaseUrl(TestConfigProvider.getHost())
+        CogniteClient client = TestConfigProvider.getCogniteClient()
                 //.withClientConfig(config)
                 ;
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",

--- a/src/test/java/com/cognite/client/EntityMatchingIntegrationTest.java
+++ b/src/test/java/com/cognite/client/EntityMatchingIntegrationTest.java
@@ -33,12 +33,7 @@ class EntityMatchingIntegrationTest {
                 .withNoListPartitions(1);
         String loggingPrefix = "UnitTest - matchEntitiesStruct() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
-        CogniteClient client = CogniteClient.ofClientCredentials(
-                    TestConfigProvider.getProject(),
-                    TestConfigProvider.getClientId(),
-                    TestConfigProvider.getClientSecret(),
-                    TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withBaseUrl(TestConfigProvider.getHost())
+        CogniteClient client = TestConfigProvider.getCogniteClient()
                 //.withClientConfig(config)
                 ;
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",

--- a/src/test/java/com/cognite/client/EntityMatchingIntegrationTest.java
+++ b/src/test/java/com/cognite/client/EntityMatchingIntegrationTest.java
@@ -34,10 +34,10 @@ class EntityMatchingIntegrationTest {
         String loggingPrefix = "UnitTest - matchEntitiesStruct() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
         CogniteClient client = CogniteClient.ofClientCredentials(
+                    TestConfigProvider.getProject(),
                     TestConfigProvider.getClientId(),
                     TestConfigProvider.getClientSecret(),
                     TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withProject(TestConfigProvider.getProject())
                     .withBaseUrl(TestConfigProvider.getHost())
                 //.withClientConfig(config)
                 ;

--- a/src/test/java/com/cognite/client/EventsIntegrationTest.java
+++ b/src/test/java/com/cognite/client/EventsIntegrationTest.java
@@ -43,10 +43,10 @@ class EventsIntegrationTest {
 
         try {
             CogniteClient client = CogniteClient.ofClientCredentials(
+                    TestConfigProvider.getProject(),
                     TestConfigProvider.getClientId(),
                     TestConfigProvider.getClientSecret(),
                     TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withProject(TestConfigProvider.getProject())
                     .withBaseUrl(TestConfigProvider.getHost());
             //client = client.withScopes(List.of("https://greenfield.cognitedata.com/.default"));
             //client = client.withBaseUrl("https://greenfield.cognitedata.com");
@@ -103,10 +103,10 @@ class EventsIntegrationTest {
         String loggingPrefix = "UnitTest - writeEditAndDeleteEvents() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
         CogniteClient client = CogniteClient.ofClientCredentials(
+                    TestConfigProvider.getProject(),
                     TestConfigProvider.getClientId(),
                     TestConfigProvider.getClientSecret(),
                     TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withProject(TestConfigProvider.getProject())
                     .withBaseUrl(TestConfigProvider.getHost())
                 //.withClientConfig(config)
                 ;
@@ -220,10 +220,10 @@ class EventsIntegrationTest {
         String loggingPrefix = "UnitTest - writeReadAndDeleteEvents() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
         CogniteClient client = CogniteClient.ofClientCredentials(
+                    TestConfigProvider.getProject(),
                     TestConfigProvider.getClientId(),
                     TestConfigProvider.getClientSecret(),
                     TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withProject(TestConfigProvider.getProject())
                     .withBaseUrl(TestConfigProvider.getHost())
                 //.withClientConfig(config)
                 ;
@@ -288,10 +288,10 @@ class EventsIntegrationTest {
         String loggingPrefix = "UnitTest - writeAggregateAndDeleteEvents() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
         CogniteClient client = CogniteClient.ofClientCredentials(
+                    TestConfigProvider.getProject(),
                     TestConfigProvider.getClientId(),
                     TestConfigProvider.getClientSecret(),
                     TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withProject(TestConfigProvider.getProject())
                     .withBaseUrl(TestConfigProvider.getHost())
                 ;
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",

--- a/src/test/java/com/cognite/client/EventsIntegrationTest.java
+++ b/src/test/java/com/cognite/client/EventsIntegrationTest.java
@@ -42,12 +42,7 @@ class EventsIntegrationTest {
 
 
         try {
-            CogniteClient client = CogniteClient.ofClientCredentials(
-                    TestConfigProvider.getProject(),
-                    TestConfigProvider.getClientId(),
-                    TestConfigProvider.getClientSecret(),
-                    TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withBaseUrl(TestConfigProvider.getHost());
+            CogniteClient client = TestConfigProvider.getCogniteClient();
             //client = client.withScopes(List.of("https://greenfield.cognitedata.com/.default"));
             //client = client.withBaseUrl("https://greenfield.cognitedata.com");
             LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",
@@ -102,12 +97,7 @@ class EventsIntegrationTest {
                 .withNoListPartitions(1);
         String loggingPrefix = "UnitTest - writeEditAndDeleteEvents() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
-        CogniteClient client = CogniteClient.ofClientCredentials(
-                    TestConfigProvider.getProject(),
-                    TestConfigProvider.getClientId(),
-                    TestConfigProvider.getClientSecret(),
-                    TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withBaseUrl(TestConfigProvider.getHost())
+        CogniteClient client = TestConfigProvider.getCogniteClient()
                 //.withClientConfig(config)
                 ;
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",
@@ -219,12 +209,7 @@ class EventsIntegrationTest {
         Instant startInstant = Instant.now();
         String loggingPrefix = "UnitTest - writeReadAndDeleteEvents() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
-        CogniteClient client = CogniteClient.ofClientCredentials(
-                    TestConfigProvider.getProject(),
-                    TestConfigProvider.getClientId(),
-                    TestConfigProvider.getClientSecret(),
-                    TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withBaseUrl(TestConfigProvider.getHost())
+        CogniteClient client = TestConfigProvider.getCogniteClient()
                 //.withClientConfig(config)
                 ;
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",
@@ -287,12 +272,7 @@ class EventsIntegrationTest {
 
         String loggingPrefix = "UnitTest - writeAggregateAndDeleteEvents() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
-        CogniteClient client = CogniteClient.ofClientCredentials(
-                    TestConfigProvider.getProject(),
-                    TestConfigProvider.getClientId(),
-                    TestConfigProvider.getClientSecret(),
-                    TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withBaseUrl(TestConfigProvider.getHost())
+        CogniteClient client = TestConfigProvider.getCogniteClient()
                 ;
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",
                 Duration.between(startInstant, Instant.now()));
@@ -350,12 +330,7 @@ class EventsIntegrationTest {
 
         String loggingPrefix = "UnitTest - writeStreamAndDeleteEvents() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
-        CogniteClient client = CogniteClient.ofClientCredentials(
-                        TestConfigProvider.getClientId(),
-                        TestConfigProvider.getClientSecret(),
-                        TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                .withProject(TestConfigProvider.getProject())
-                .withBaseUrl(TestConfigProvider.getHost())
+        CogniteClient client = TestConfigProvider.getCogniteClient()
                 //.withClientConfig(config)
                 ;
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",
@@ -437,12 +412,7 @@ class EventsIntegrationTest {
         String loggingPrefix = "UnitTest - writeUploadQueueAndDeleteEvents() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
 
-        CogniteClient client = CogniteClient.ofClientCredentials(
-                        TestConfigProvider.getClientId(),
-                        TestConfigProvider.getClientSecret(),
-                        TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                .withProject(TestConfigProvider.getProject())
-                .withBaseUrl(TestConfigProvider.getHost());
+        CogniteClient client = TestConfigProvider.getCogniteClient();
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",
                 Duration.between(startInstant, Instant.now()));
         LOG.info(loggingPrefix + "----------------------------------------------------------------------");

--- a/src/test/java/com/cognite/client/ExtractionPipelinesIntegrationTest.java
+++ b/src/test/java/com/cognite/client/ExtractionPipelinesIntegrationTest.java
@@ -26,12 +26,7 @@ class ExtractionPipelinesIntegrationTest {
         String loggingPrefix = "UnitTest - writeReadAndDeleteExtractionPipelines() -";
         LOG.info(loggingPrefix + "---------------- Start test. Creating Cognite client. --------------------");
 
-        CogniteClient client = CogniteClient.ofClientCredentials(
-                TestConfigProvider.getClientId(),
-                TestConfigProvider.getClientSecret(),
-                TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                .withProject(TestConfigProvider.getProject())
-                .withBaseUrl(TestConfigProvider.getHost());
+        CogniteClient client = TestConfigProvider.getCogniteClient();
         LOG.info(loggingPrefix + "-------------- Finished creating the Cognite client. Duration : {} ---------------",
                 Duration.between(startInstant, Instant.now()));
 

--- a/src/test/java/com/cognite/client/FilesIntegrationTest.java
+++ b/src/test/java/com/cognite/client/FilesIntegrationTest.java
@@ -35,12 +35,7 @@ class FilesIntegrationTest {
         String loggingPrefix = "UnitTest - downloadValidateUri() -";
         LOG.info(loggingPrefix + "----------------------------------------------------------------------");
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
-        CogniteClient client = CogniteClient.ofClientCredentials(
-                        TestConfigProvider.getClientId(),
-                        TestConfigProvider.getClientSecret(),
-                        TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                .withProject(TestConfigProvider.getProject())
-                .withBaseUrl(TestConfigProvider.getHost())
+        CogniteClient client = TestConfigProvider.getCogniteClient()
                 //.withClientConfig(config)
                 ;
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",
@@ -97,12 +92,7 @@ class FilesIntegrationTest {
         String loggingPrefix = "UnitTest - writeReadAndDeleteFiles() -";
         LOG.info(loggingPrefix + "----------------------------------------------------------------------");
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
-        CogniteClient client = CogniteClient.ofClientCredentials(
-                        TestConfigProvider.getClientId(),
-                        TestConfigProvider.getClientSecret(),
-                        TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                .withProject(TestConfigProvider.getProject())
-                .withBaseUrl(TestConfigProvider.getHost())
+        CogniteClient client = TestConfigProvider.getCogniteClient()
                 //.withClientConfig(config)
                 ;
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",
@@ -193,12 +183,7 @@ class FilesIntegrationTest {
         String loggingPrefix = "UnitTest - writeReadAndDeleteFiles() -";
         LOG.info(loggingPrefix + "----------------------------------------------------------------------");
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
-        CogniteClient client = CogniteClient.ofClientCredentials(
-                        TestConfigProvider.getClientId(),
-                        TestConfigProvider.getClientSecret(),
-                        TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                .withProject(TestConfigProvider.getProject())
-                .withBaseUrl(TestConfigProvider.getHost())
+        CogniteClient client = TestConfigProvider.getCogniteClient()
                 //.withClientConfig(config)
                 ;
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",
@@ -251,12 +236,7 @@ class FilesIntegrationTest {
         String loggingPrefix = "UnitTest - readFiles() -";
         LOG.info(loggingPrefix + "----------------------------------------------------------------------");
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
-        CogniteClient client = CogniteClient.ofClientCredentials(
-                        TestConfigProvider.getClientId(),
-                        TestConfigProvider.getClientSecret(),
-                        TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                .withProject(TestConfigProvider.getProject())
-                .withBaseUrl(TestConfigProvider.getHost());
+        CogniteClient client = TestConfigProvider.getCogniteClient();
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",
                 Duration.between(startInstant, Instant.now()));
         LOG.info(loggingPrefix + "----------------------------------------------------------------------");
@@ -330,12 +310,7 @@ class FilesIntegrationTest {
         String loggingPrefix = "UnitTest - writeReadAndDeleteFiles() -";
         LOG.info(loggingPrefix + "----------------------------------------------------------------------");
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
-        CogniteClient client = CogniteClient.ofClientCredentials(
-                        TestConfigProvider.getClientId(),
-                        TestConfigProvider.getClientSecret(),
-                        TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                .withProject(TestConfigProvider.getProject())
-                .withBaseUrl(TestConfigProvider.getHost())
+        CogniteClient client = TestConfigProvider.getCogniteClient()
                 ;
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",
                 Duration.between(startInstant, Instant.now()));

--- a/src/test/java/com/cognite/client/LabelsIntegrationTest.java
+++ b/src/test/java/com/cognite/client/LabelsIntegrationTest.java
@@ -34,12 +34,7 @@ class LabelsIntegrationTest {
                 .withNoListPartitions(1);
         String loggingPrefix = "UnitTest - writeReadAndDeleteLabels() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
-        CogniteClient client = CogniteClient.ofClientCredentials(
-                    TestConfigProvider.getProject(),
-                    TestConfigProvider.getClientId(),
-                    TestConfigProvider.getClientSecret(),
-                    TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withBaseUrl(TestConfigProvider.getHost())
+        CogniteClient client = TestConfigProvider.getCogniteClient()
                 //.withClientConfig(config)
                 ;
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",
@@ -92,12 +87,7 @@ class LabelsIntegrationTest {
                 .withNoListPartitions(1);
         String loggingPrefix = "UnitTest - writeEditAndDeleteLabels() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
-        CogniteClient client = CogniteClient.ofClientCredentials(
-                    TestConfigProvider.getProject(),
-                    TestConfigProvider.getClientId(),
-                    TestConfigProvider.getClientSecret(),
-                    TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withBaseUrl(TestConfigProvider.getHost())
+        CogniteClient client = TestConfigProvider.getCogniteClient()
                 //.withClientConfig(config)
                 ;
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",

--- a/src/test/java/com/cognite/client/LabelsIntegrationTest.java
+++ b/src/test/java/com/cognite/client/LabelsIntegrationTest.java
@@ -35,10 +35,10 @@ class LabelsIntegrationTest {
         String loggingPrefix = "UnitTest - writeReadAndDeleteLabels() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
         CogniteClient client = CogniteClient.ofClientCredentials(
+                    TestConfigProvider.getProject(),
                     TestConfigProvider.getClientId(),
                     TestConfigProvider.getClientSecret(),
                     TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withProject(TestConfigProvider.getProject())
                     .withBaseUrl(TestConfigProvider.getHost())
                 //.withClientConfig(config)
                 ;
@@ -93,10 +93,10 @@ class LabelsIntegrationTest {
         String loggingPrefix = "UnitTest - writeEditAndDeleteLabels() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
         CogniteClient client = CogniteClient.ofClientCredentials(
+                    TestConfigProvider.getProject(),
                     TestConfigProvider.getClientId(),
                     TestConfigProvider.getClientSecret(),
                     TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withProject(TestConfigProvider.getProject())
                     .withBaseUrl(TestConfigProvider.getHost())
                 //.withClientConfig(config)
                 ;

--- a/src/test/java/com/cognite/client/RawIntegrationTest.java
+++ b/src/test/java/com/cognite/client/RawIntegrationTest.java
@@ -38,12 +38,7 @@ class RawIntegrationTest {
                 .withNoListPartitions(1);
         String loggingPrefix = "UnitTest - writeReadAndDeleteRaw() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
-        CogniteClient client = CogniteClient.ofClientCredentials(
-                    TestConfigProvider.getProject(),
-                    TestConfigProvider.getClientId(),
-                    TestConfigProvider.getClientSecret(),
-                    TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withBaseUrl(TestConfigProvider.getHost())
+        CogniteClient client = TestConfigProvider.getCogniteClient()
                 //.withClientConfig(config)
                 ;
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",
@@ -175,12 +170,7 @@ class RawIntegrationTest {
 
         String loggingPrefix = "UnitTest - writeStreamAndDeleteRaw() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
-        CogniteClient client = CogniteClient.ofClientCredentials(
-                    TestConfigProvider.getProject(),
-                    TestConfigProvider.getClientId(),
-                    TestConfigProvider.getClientSecret(),
-                    TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withBaseUrl(TestConfigProvider.getHost())
+        CogniteClient client = TestConfigProvider.getCogniteClient()
                 //.withClientConfig(config)
                 ;
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",

--- a/src/test/java/com/cognite/client/RawIntegrationTest.java
+++ b/src/test/java/com/cognite/client/RawIntegrationTest.java
@@ -39,10 +39,10 @@ class RawIntegrationTest {
         String loggingPrefix = "UnitTest - writeReadAndDeleteRaw() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
         CogniteClient client = CogniteClient.ofClientCredentials(
+                    TestConfigProvider.getProject(),
                     TestConfigProvider.getClientId(),
                     TestConfigProvider.getClientSecret(),
                     TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withProject(TestConfigProvider.getProject())
                     .withBaseUrl(TestConfigProvider.getHost())
                 //.withClientConfig(config)
                 ;
@@ -176,10 +176,10 @@ class RawIntegrationTest {
         String loggingPrefix = "UnitTest - writeStreamAndDeleteRaw() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
         CogniteClient client = CogniteClient.ofClientCredentials(
+                    TestConfigProvider.getProject(),
                     TestConfigProvider.getClientId(),
                     TestConfigProvider.getClientSecret(),
                     TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withProject(TestConfigProvider.getProject())
                     .withBaseUrl(TestConfigProvider.getHost())
                 //.withClientConfig(config)
                 ;

--- a/src/test/java/com/cognite/client/RelationshipsIntegrationTest.java
+++ b/src/test/java/com/cognite/client/RelationshipsIntegrationTest.java
@@ -37,10 +37,10 @@ class RelationshipsIntegrationTest {
         String loggingPrefix = "UnitTest - writeReadAndDeleteRelationships() -";
         LOG.info(loggingPrefix + "------------------- Start test. Creating Cognite client. ----------------------");
         CogniteClient client = CogniteClient.ofClientCredentials(
+                    TestConfigProvider.getProject(),
                     TestConfigProvider.getClientId(),
                     TestConfigProvider.getClientSecret(),
                     TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withProject(TestConfigProvider.getProject())
                     .withBaseUrl(TestConfigProvider.getHost())
                 ;
         LOG.info(loggingPrefix + "------------------- Finished creating the Cognite client. Duration : {} ------------------",
@@ -174,10 +174,10 @@ class RelationshipsIntegrationTest {
         String loggingPrefix = "UnitTest - writeEditAndDeleteRelationships() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
         CogniteClient client = CogniteClient.ofClientCredentials(
+                    TestConfigProvider.getProject(),
                     TestConfigProvider.getClientId(),
                     TestConfigProvider.getClientSecret(),
                     TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withProject(TestConfigProvider.getProject())
                     .withBaseUrl(TestConfigProvider.getHost())
                 ;
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",
@@ -250,10 +250,10 @@ class RelationshipsIntegrationTest {
         String loggingPrefix = "UnitTest - writeRetrieveAndDeleteRelationships() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
         CogniteClient client = CogniteClient.ofClientCredentials(
+                    TestConfigProvider.getProject(),
                     TestConfigProvider.getClientId(),
                     TestConfigProvider.getClientSecret(),
                     TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withProject(TestConfigProvider.getProject())
                     .withBaseUrl(TestConfigProvider.getHost())
                 ;
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",

--- a/src/test/java/com/cognite/client/RelationshipsIntegrationTest.java
+++ b/src/test/java/com/cognite/client/RelationshipsIntegrationTest.java
@@ -36,12 +36,7 @@ class RelationshipsIntegrationTest {
 
         String loggingPrefix = "UnitTest - writeReadAndDeleteRelationships() -";
         LOG.info(loggingPrefix + "------------------- Start test. Creating Cognite client. ----------------------");
-        CogniteClient client = CogniteClient.ofClientCredentials(
-                    TestConfigProvider.getProject(),
-                    TestConfigProvider.getClientId(),
-                    TestConfigProvider.getClientSecret(),
-                    TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withBaseUrl(TestConfigProvider.getHost())
+        CogniteClient client = TestConfigProvider.getCogniteClient()
                 ;
         LOG.info(loggingPrefix + "------------------- Finished creating the Cognite client. Duration : {} ------------------",
                 Duration.between(startInstant, Instant.now()));
@@ -173,12 +168,7 @@ class RelationshipsIntegrationTest {
         Instant startInstant = Instant.now();
         String loggingPrefix = "UnitTest - writeEditAndDeleteRelationships() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
-        CogniteClient client = CogniteClient.ofClientCredentials(
-                    TestConfigProvider.getProject(),
-                    TestConfigProvider.getClientId(),
-                    TestConfigProvider.getClientSecret(),
-                    TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withBaseUrl(TestConfigProvider.getHost())
+        CogniteClient client = TestConfigProvider.getCogniteClient()
                 ;
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",
                 Duration.between(startInstant, Instant.now()));
@@ -249,12 +239,7 @@ class RelationshipsIntegrationTest {
         Instant startInstant = Instant.now();
         String loggingPrefix = "UnitTest - writeRetrieveAndDeleteRelationships() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
-        CogniteClient client = CogniteClient.ofClientCredentials(
-                    TestConfigProvider.getProject(),
-                    TestConfigProvider.getClientId(),
-                    TestConfigProvider.getClientSecret(),
-                    TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withBaseUrl(TestConfigProvider.getHost())
+        CogniteClient client = TestConfigProvider.getCogniteClient()
                 ;
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",
                 Duration.between(startInstant, Instant.now()));

--- a/src/test/java/com/cognite/client/SecurityCategoriesIntegrationTest.java
+++ b/src/test/java/com/cognite/client/SecurityCategoriesIntegrationTest.java
@@ -28,12 +28,7 @@ class SecurityCategoriesIntegrationTest {
                 .withNoListPartitions(1);
         String loggingPrefix = "UnitTest - writeListAndDeleteSecurityCategories() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
-        CogniteClient client = CogniteClient.ofClientCredentials(
-                    TestConfigProvider.getProject(),
-                    TestConfigProvider.getClientId(),
-                    TestConfigProvider.getClientSecret(),
-                    TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withBaseUrl(TestConfigProvider.getHost())
+        CogniteClient client = TestConfigProvider.getCogniteClient()
                 //.withClientConfig(config)
                 ;
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",

--- a/src/test/java/com/cognite/client/SecurityCategoriesIntegrationTest.java
+++ b/src/test/java/com/cognite/client/SecurityCategoriesIntegrationTest.java
@@ -29,10 +29,10 @@ class SecurityCategoriesIntegrationTest {
         String loggingPrefix = "UnitTest - writeListAndDeleteSecurityCategories() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
         CogniteClient client = CogniteClient.ofClientCredentials(
+                    TestConfigProvider.getProject(),
                     TestConfigProvider.getClientId(),
                     TestConfigProvider.getClientSecret(),
                     TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withProject(TestConfigProvider.getProject())
                     .withBaseUrl(TestConfigProvider.getHost())
                 //.withClientConfig(config)
                 ;

--- a/src/test/java/com/cognite/client/SequencesIntegrationTest.java
+++ b/src/test/java/com/cognite/client/SequencesIntegrationTest.java
@@ -38,12 +38,7 @@ class SequencesIntegrationTest {
                 .withNoListPartitions(1);
         String loggingPrefix = "UnitTest - writeReadAndDeleteSequences() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
-        CogniteClient client = CogniteClient.ofClientCredentials(
-                    TestConfigProvider.getProject(),
-                    TestConfigProvider.getClientId(),
-                    TestConfigProvider.getClientSecret(),
-                    TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withBaseUrl(TestConfigProvider.getHost())
+        CogniteClient client = TestConfigProvider.getCogniteClient()
                 //.withClientConfig(config)
                 ;
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",
@@ -94,12 +89,7 @@ class SequencesIntegrationTest {
         String loggingPrefix = "UnitTest - writeReadAndDeleteSequencesRows() -";
         LOG.info(loggingPrefix + "----------------------------------------------------------------------");
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
-        CogniteClient client = CogniteClient.ofClientCredentials(
-                    TestConfigProvider.getProject(),
-                    TestConfigProvider.getClientId(),
-                    TestConfigProvider.getClientSecret(),
-                    TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withBaseUrl(TestConfigProvider.getHost())
+        CogniteClient client = TestConfigProvider.getCogniteClient()
                 //.withClientConfig(config)
                 ;
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",
@@ -190,12 +180,7 @@ class SequencesIntegrationTest {
         String loggingPrefix = "UnitTest - writeEditReadAndDeleteSequencesRows() -";
         LOG.info(loggingPrefix + "----------------------------------------------------------------------");
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
-        CogniteClient client = CogniteClient.ofClientCredentials(
-                        TestConfigProvider.getClientId(),
-                        TestConfigProvider.getClientSecret(),
-                        TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                .withProject(TestConfigProvider.getProject())
-                .withBaseUrl(TestConfigProvider.getHost())
+        CogniteClient client = TestConfigProvider.getCogniteClient()
                 //.withClientConfig(config)
                 ;
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",
@@ -362,12 +347,7 @@ class SequencesIntegrationTest {
                 .withNoListPartitions(1);
         String loggingPrefix = "UnitTest - writeEditAndDeleteSequences() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
-        CogniteClient client = CogniteClient.ofClientCredentials(
-                    TestConfigProvider.getProject(),
-                    TestConfigProvider.getClientId(),
-                    TestConfigProvider.getClientSecret(),
-                    TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withBaseUrl(TestConfigProvider.getHost())
+        CogniteClient client = TestConfigProvider.getCogniteClient()
                 //.withClientConfig(config)
                 ;
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",
@@ -492,12 +472,7 @@ class SequencesIntegrationTest {
         Instant startInstant = Instant.now();
         String loggingPrefix = "UnitTest - writeReadAndDeleteSequences() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
-        CogniteClient client = CogniteClient.ofClientCredentials(
-                    TestConfigProvider.getProject(),
-                    TestConfigProvider.getClientId(),
-                    TestConfigProvider.getClientSecret(),
-                    TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withBaseUrl(TestConfigProvider.getHost())
+        CogniteClient client = TestConfigProvider.getCogniteClient()
                 //.withClientConfig(config)
                 ;
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",
@@ -562,12 +537,7 @@ class SequencesIntegrationTest {
 
         String loggingPrefix = "UnitTest - writeAggregateAndDeleteSequences() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
-        CogniteClient client = CogniteClient.ofClientCredentials(
-                    TestConfigProvider.getProject(),
-                    TestConfigProvider.getClientId(),
-                    TestConfigProvider.getClientSecret(),
-                    TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withBaseUrl(TestConfigProvider.getHost())
+        CogniteClient client = TestConfigProvider.getCogniteClient()
                 ;
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",
                 Duration.between(startInstant, Instant.now()));

--- a/src/test/java/com/cognite/client/SequencesIntegrationTest.java
+++ b/src/test/java/com/cognite/client/SequencesIntegrationTest.java
@@ -39,10 +39,10 @@ class SequencesIntegrationTest {
         String loggingPrefix = "UnitTest - writeReadAndDeleteSequences() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
         CogniteClient client = CogniteClient.ofClientCredentials(
+                    TestConfigProvider.getProject(),
                     TestConfigProvider.getClientId(),
                     TestConfigProvider.getClientSecret(),
                     TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withProject(TestConfigProvider.getProject())
                     .withBaseUrl(TestConfigProvider.getHost())
                 //.withClientConfig(config)
                 ;
@@ -95,10 +95,10 @@ class SequencesIntegrationTest {
         LOG.info(loggingPrefix + "----------------------------------------------------------------------");
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
         CogniteClient client = CogniteClient.ofClientCredentials(
+                    TestConfigProvider.getProject(),
                     TestConfigProvider.getClientId(),
                     TestConfigProvider.getClientSecret(),
                     TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withProject(TestConfigProvider.getProject())
                     .withBaseUrl(TestConfigProvider.getHost())
                 //.withClientConfig(config)
                 ;
@@ -363,10 +363,10 @@ class SequencesIntegrationTest {
         String loggingPrefix = "UnitTest - writeEditAndDeleteSequences() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
         CogniteClient client = CogniteClient.ofClientCredentials(
+                    TestConfigProvider.getProject(),
                     TestConfigProvider.getClientId(),
                     TestConfigProvider.getClientSecret(),
                     TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withProject(TestConfigProvider.getProject())
                     .withBaseUrl(TestConfigProvider.getHost())
                 //.withClientConfig(config)
                 ;
@@ -493,10 +493,10 @@ class SequencesIntegrationTest {
         String loggingPrefix = "UnitTest - writeReadAndDeleteSequences() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
         CogniteClient client = CogniteClient.ofClientCredentials(
+                    TestConfigProvider.getProject(),
                     TestConfigProvider.getClientId(),
                     TestConfigProvider.getClientSecret(),
                     TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withProject(TestConfigProvider.getProject())
                     .withBaseUrl(TestConfigProvider.getHost())
                 //.withClientConfig(config)
                 ;
@@ -563,10 +563,10 @@ class SequencesIntegrationTest {
         String loggingPrefix = "UnitTest - writeAggregateAndDeleteSequences() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
         CogniteClient client = CogniteClient.ofClientCredentials(
+                    TestConfigProvider.getProject(),
                     TestConfigProvider.getClientId(),
                     TestConfigProvider.getClientSecret(),
                     TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withProject(TestConfigProvider.getProject())
                     .withBaseUrl(TestConfigProvider.getHost())
                 ;
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",

--- a/src/test/java/com/cognite/client/TestConfigProvider.java
+++ b/src/test/java/com/cognite/client/TestConfigProvider.java
@@ -1,11 +1,32 @@
 package com.cognite.client;
 
+import com.cognite.client.config.TokenUrl;
 import com.google.common.base.Strings;
+
+import java.net.MalformedURLException;
 
 /**
  * Utility class for setting the client configuration for test runs.
  */
 public class TestConfigProvider {
+    public static CogniteClient getCogniteClient() throws MalformedURLException {
+        return CogniteClient.ofClientCredentials(
+                        TestConfigProvider.getProject(),
+                        TestConfigProvider.getClientId(),
+                        TestConfigProvider.getClientSecret(),
+                        TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
+                .withBaseUrl(TestConfigProvider.getHost());
+    }
+
+    public static CogniteClient getOpenIndustrialDataCogniteClient() throws MalformedURLException {
+        return CogniteClient.ofClientCredentials(
+                TestConfigProvider.getOpenIndustrialDataProject(),
+                TestConfigProvider.getOpenIndustrialDataClientId(),
+                TestConfigProvider.getOpenIndustrialDataClientSecret(),
+                TokenUrl.generateAzureAdURL(TestConfigProvider.getOpenIndustrialDataTenantId())
+        );
+    }
+
     public static String getOpenIndustrialDataProject() {
         return "publicdata";
     }

--- a/src/test/java/com/cognite/client/TestConfigProvider.java
+++ b/src/test/java/com/cognite/client/TestConfigProvider.java
@@ -6,6 +6,25 @@ import com.google.common.base.Strings;
  * Utility class for setting the client configuration for test runs.
  */
 public class TestConfigProvider {
+    public static String getOpenIndustrialDataProject() {
+        return "publicdata";
+    }
+
+    public static String getOpenIndustrialDataClientId() {
+        return "1b90ede3-271e-401b-81a0-a4d52bea3273"; // public info
+    }
+
+    public static String getOpenIndustrialDataClientSecret() {
+        String clientSecret = System.getenv("OPEN_IND_DATA_CLIENT_SECRET");
+        if (Strings.isNullOrEmpty(clientSecret)) {
+            clientSecret = "test";
+        }
+        return clientSecret;
+    }
+
+    public static String getOpenIndustrialDataTenantId() {
+        return "48d5043c-cf70-4c49-881c-c638f5796997"; // public info
+    }
 
     public static String getProject() {
         String project = System.getenv("TEST_PROJECT");

--- a/src/test/java/com/cognite/client/ThreeDAssetMappingsIntegrationTest.java
+++ b/src/test/java/com/cognite/client/ThreeDAssetMappingsIntegrationTest.java
@@ -192,7 +192,7 @@ public class ThreeDAssetMappingsIntegrationTest extends ThreeDBaseIntegrationTes
     @Tag("remoteCDP")
     public void testListPublicData() throws Exception {
         try {
-            CogniteClient client = getCogniteClientAPIKey();
+            CogniteClient client = getCogniteClientOpenIndustrialData();
             Iterator<List<ThreeDAssetMapping>> itFilter = client.threeD()
                     .models()
                     .revisions()
@@ -214,7 +214,7 @@ public class ThreeDAssetMappingsIntegrationTest extends ThreeDBaseIntegrationTes
 
             Request request = Request.create()
                     .withRootParameter("limit", 1);
-            CogniteClient client = getCogniteClientAPIKey();
+            CogniteClient client = getCogniteClientOpenIndustrialData();
             Iterator<List<ThreeDAssetMapping>> itFilter = client.threeD()
                     .models()
                     .revisions()
@@ -253,7 +253,7 @@ public class ThreeDAssetMappingsIntegrationTest extends ThreeDBaseIntegrationTes
 
             Request request = Request.create()
                     .withRootParameter("limit", 1);
-            CogniteClient client = getCogniteClientAPIKey();
+            CogniteClient client = getCogniteClientOpenIndustrialData();
             Iterator<List<ThreeDAssetMapping>> itFilter = client.threeD()
                     .models()
                     .revisions()
@@ -292,7 +292,7 @@ public class ThreeDAssetMappingsIntegrationTest extends ThreeDBaseIntegrationTes
 
             Request request = Request.create()
                     .withRootParameter("limit", 1);
-            CogniteClient client = getCogniteClientAPIKey();
+            CogniteClient client = getCogniteClientOpenIndustrialData();
             Iterator<List<ThreeDAssetMapping>> itFilter = client.threeD()
                     .models()
                     .revisions()
@@ -328,7 +328,7 @@ public class ThreeDAssetMappingsIntegrationTest extends ThreeDBaseIntegrationTes
     public void testFilterPublicData() throws Exception {
         try {
 
-            CogniteClient client = getCogniteClientAPIKey();
+            CogniteClient client = getCogniteClientOpenIndustrialData();
             Iterator<List<ThreeDAssetMapping>> itFilter = client.threeD()
                     .models()
                     .revisions()
@@ -352,7 +352,7 @@ public class ThreeDAssetMappingsIntegrationTest extends ThreeDBaseIntegrationTes
 
             Request request = Request.create()
                     .withRootParameter("limit", 100);
-            CogniteClient client = getCogniteClientAPIKey();
+            CogniteClient client = getCogniteClientOpenIndustrialData();
             Iterator<List<ThreeDAssetMapping>> itFilter = client.threeD()
                     .models()
                     .revisions()
@@ -396,7 +396,7 @@ public class ThreeDAssetMappingsIntegrationTest extends ThreeDBaseIntegrationTes
 
             Request request = Request.create()
                     .withRootParameter("limit", 100);
-            CogniteClient client = getCogniteClientAPIKey();
+            CogniteClient client = getCogniteClientOpenIndustrialData();
             Iterator<List<ThreeDAssetMapping>> itFilter = client.threeD()
                     .models()
                     .revisions()
@@ -438,7 +438,7 @@ public class ThreeDAssetMappingsIntegrationTest extends ThreeDBaseIntegrationTes
 
             Request request = Request.create()
                     .withRootParameter("limit", 100);
-            CogniteClient client = getCogniteClientAPIKey();
+            CogniteClient client = getCogniteClientOpenIndustrialData();
             Iterator<List<ThreeDAssetMapping>> itFilter = client.threeD()
                     .models()
                     .revisions()

--- a/src/test/java/com/cognite/client/ThreeDBaseIntegrationTest.java
+++ b/src/test/java/com/cognite/client/ThreeDBaseIntegrationTest.java
@@ -81,23 +81,11 @@ public abstract class ThreeDBaseIntegrationTest {
     }
 
     private CogniteClient getClientOpenIndustrialData() throws MalformedURLException {
-        return CogniteClient.ofClientCredentials(
-                TestConfigProvider.getOpenIndustrialDataProject(),
-                TestConfigProvider.getOpenIndustrialDataClientId(),
-                TestConfigProvider.getOpenIndustrialDataClientSecret(),
-                TokenUrl.generateAzureAdURL(TestConfigProvider.getOpenIndustrialDataTenantId())
-        );
+        return TestConfigProvider.getOpenIndustrialDataCogniteClient();
     }
 
     private CogniteClient getClientCredential() throws MalformedURLException {
-        CogniteClient client = CogniteClient.ofClientCredentials(
-                        TestConfigProvider.getProject(),
-                        TestConfigProvider.getClientId(),
-                        TestConfigProvider.getClientSecret(),
-                        TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                .withBaseUrl(TestConfigProvider.getHost());
-
-        return client;
+        return TestConfigProvider.getCogniteClient();
     }
 
     @NotNull
@@ -160,12 +148,7 @@ public abstract class ThreeDBaseIntegrationTest {
                     .build();
             fileContainerInput.add(fileContainer);
 
-            CogniteClient client = CogniteClient.ofClientCredentials(
-                    TestConfigProvider.getProject(),
-                    TestConfigProvider.getClientId(),
-                    TestConfigProvider.getClientSecret(),
-                    TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withBaseUrl(TestConfigProvider.getHost());
+            CogniteClient client = TestConfigProvider.getCogniteClient();
 
             try {
                 List<FileMetadata> uploadFileResult = client.files().upload(fileContainerInput);

--- a/src/test/java/com/cognite/client/ThreeDBaseIntegrationTest.java
+++ b/src/test/java/com/cognite/client/ThreeDBaseIntegrationTest.java
@@ -21,9 +21,6 @@ import java.util.stream.Collectors;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public abstract class ThreeDBaseIntegrationTest {
-
-    private static final String PUBLIC_DATA_API_KEY = "OWIyZWEwNjctMDFmNy00MjI0LWE5NDctYmRjMTcwYTU0Y2Jj";
-
     protected static final Integer COUNT_TO_BE_CREATE = 2;
 
     abstract Logger getLogger();
@@ -74,25 +71,30 @@ public abstract class ThreeDBaseIntegrationTest {
         return client;
     }
 
-    protected CogniteClient getCogniteClientAPIKey() throws MalformedURLException {
+    protected CogniteClient getCogniteClientOpenIndustrialData() throws MalformedURLException {
         Instant startInstant = Instant.now();
-        getLogger().info("------------ Start test. Creating Cognite client - API-KEY------------");
-        CogniteClient client = getClienteOfApiKey();
-        getLogger().info("------------ Finished creating the Cognite client - API-KEY. Duration : {}",
+        getLogger().info("------------ Start test. Creating Cognite client - Open Industrial Data ------------");
+        CogniteClient client = getClientOpenIndustrialData();
+        getLogger().info("------------ Finished creating the Cognite client - Open Industrial Data. Duration : {}",
                 Duration.between(startInstant, Instant.now()) + " ------------");
         return client;
     }
 
-    private CogniteClient getClienteOfApiKey() {
-        return CogniteClient.ofKey(PUBLIC_DATA_API_KEY);
+    private CogniteClient getClientOpenIndustrialData() throws MalformedURLException {
+        return CogniteClient.ofClientCredentials(
+                TestConfigProvider.getOpenIndustrialDataProject(),
+                TestConfigProvider.getOpenIndustrialDataClientId(),
+                TestConfigProvider.getOpenIndustrialDataClientSecret(),
+                TokenUrl.generateAzureAdURL(TestConfigProvider.getOpenIndustrialDataTenantId())
+        );
     }
 
     private CogniteClient getClientCredential() throws MalformedURLException {
         CogniteClient client = CogniteClient.ofClientCredentials(
+                        TestConfigProvider.getProject(),
                         TestConfigProvider.getClientId(),
                         TestConfigProvider.getClientSecret(),
                         TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                .withProject(TestConfigProvider.getProject())
                 .withBaseUrl(TestConfigProvider.getHost());
 
         return client;
@@ -159,10 +161,10 @@ public abstract class ThreeDBaseIntegrationTest {
             fileContainerInput.add(fileContainer);
 
             CogniteClient client = CogniteClient.ofClientCredentials(
-                            TestConfigProvider.getClientId(),
-                            TestConfigProvider.getClientSecret(),
-                            TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withProject(TestConfigProvider.getProject())
+                    TestConfigProvider.getProject(),
+                    TestConfigProvider.getClientId(),
+                    TestConfigProvider.getClientSecret(),
+                    TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
                     .withBaseUrl(TestConfigProvider.getHost());
 
             try {

--- a/src/test/java/com/cognite/client/ThreeDFilesIntegrationTest.java
+++ b/src/test/java/com/cognite/client/ThreeDFilesIntegrationTest.java
@@ -43,12 +43,7 @@ class ThreeDFilesIntegrationTest {
     }
 
     private CogniteClient getTestCogniteClient() throws MalformedURLException {
-        CogniteClient client = CogniteClient.ofClientCredentials(
-                        TestConfigProvider.getClientId(),
-                        TestConfigProvider.getClientSecret(),
-                        TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                .withProject(TestConfigProvider.getProject())
-                .withBaseUrl(TestConfigProvider.getHost());
+        CogniteClient client = TestConfigProvider.getCogniteClient();
         return client;
     }
 

--- a/src/test/java/com/cognite/client/ThreeDModelsIntegrationTest.java
+++ b/src/test/java/com/cognite/client/ThreeDModelsIntegrationTest.java
@@ -278,12 +278,7 @@ public class ThreeDModelsIntegrationTest {
     }
 
     private CogniteClient getCogniteClient(Instant startInstant, String loggingPrefix) throws MalformedURLException {
-        CogniteClient client = CogniteClient.ofClientCredentials(
-                        TestConfigProvider.getClientId(),
-                        TestConfigProvider.getClientSecret(),
-                        TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                .withProject(TestConfigProvider.getProject())
-                .withBaseUrl(TestConfigProvider.getHost());
+        CogniteClient client = TestConfigProvider.getCogniteClient();
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",
                 Duration.between(startInstant, Instant.now()));
         return client;

--- a/src/test/java/com/cognite/client/ThreeDModelsRevisionsIntegrationTest.java
+++ b/src/test/java/com/cognite/client/ThreeDModelsRevisionsIntegrationTest.java
@@ -287,12 +287,7 @@ public class ThreeDModelsRevisionsIntegrationTest {
 
     private CogniteClient getCogniteClient(Instant startInstant, String loggingPrefix) throws MalformedURLException {
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
-        CogniteClient client = CogniteClient.ofClientCredentials(
-                        TestConfigProvider.getClientId(),
-                        TestConfigProvider.getClientSecret(),
-                        TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                .withProject(TestConfigProvider.getProject())
-                .withBaseUrl(TestConfigProvider.getHost());
+        CogniteClient client = TestConfigProvider.getCogniteClient();
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",
                 Duration.between(startInstant, Instant.now()));
         return client;
@@ -391,12 +386,7 @@ public class ThreeDModelsRevisionsIntegrationTest {
     }
 
     private FileMetadata getExistingFile(FileType type) throws Exception {
-        CogniteClient client = CogniteClient.ofClientCredentials(
-                        TestConfigProvider.getClientId(),
-                        TestConfigProvider.getClientSecret(),
-                        TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                .withProject(TestConfigProvider.getProject())
-                .withBaseUrl(TestConfigProvider.getHost());
+        CogniteClient client = TestConfigProvider.getCogniteClient();
 
         Iterator<List<FileMetadata>> it = client.files()
                 .list(Request.create()

--- a/src/test/java/com/cognite/client/ThreeDNodesIntegrationTest.java
+++ b/src/test/java/com/cognite/client/ThreeDNodesIntegrationTest.java
@@ -299,7 +299,7 @@ public class ThreeDNodesIntegrationTest extends ThreeDBaseIntegrationTest {
     @Tag("remoteCDP")
     public void testListPublicData() throws Exception {
         try {
-            CogniteClient client = getCogniteClientAPIKey();
+            CogniteClient client = getCogniteClientOpenIndustrialData();
             Iterator<List<ThreeDNode>> it = client.threeD()
                     .models()
                     .revisions()
@@ -318,7 +318,7 @@ public class ThreeDNodesIntegrationTest extends ThreeDBaseIntegrationTest {
     @Tag("remoteCDP")
     public void testFilterPublicData() throws Exception {
         try {
-            CogniteClient client = getCogniteClientAPIKey();
+            CogniteClient client = getCogniteClientOpenIndustrialData();
             Request request = Request.create()
                     .withFilterParameter("properties", createFilterPropertiesWithCategories());
 
@@ -341,7 +341,7 @@ public class ThreeDNodesIntegrationTest extends ThreeDBaseIntegrationTest {
     @Tag("remoteCDP")
     public void testFilter1CategorieAnd2ItemsPublicData() throws Exception {
         try {
-            CogniteClient client = getCogniteClientAPIKey();
+            CogniteClient client = getCogniteClientOpenIndustrialData();
             Request request = Request.create()
                     .withFilterParameter("properties", createFilterProperties1CategoriesAnd2Items());
 
@@ -364,7 +364,7 @@ public class ThreeDNodesIntegrationTest extends ThreeDBaseIntegrationTest {
     @Tag("remoteCDP")
     public void testFilterWith2ICategoriesPublicData() throws Exception {
         try {
-            CogniteClient client = getCogniteClientAPIKey();
+            CogniteClient client = getCogniteClientOpenIndustrialData();
             Request request = Request.create()
                     .withRootParameter("limit", 1)
                     .withFilterParameter("properties", createFilterPropertiesWith2Categories());
@@ -388,7 +388,7 @@ public class ThreeDNodesIntegrationTest extends ThreeDBaseIntegrationTest {
     @Tag("remoteCDP")
     public void testFilterWith2ICategoriesAnd2ItemsPublicData() throws Exception {
         try {
-            CogniteClient client = getCogniteClientAPIKey();
+            CogniteClient client = getCogniteClientOpenIndustrialData();
             Request request = Request.create()
                     .withRootParameter("limit", 1)
                     .withFilterParameter("properties", createFilterPropertiesWith2CategoriesANd2Items());
@@ -411,7 +411,7 @@ public class ThreeDNodesIntegrationTest extends ThreeDBaseIntegrationTest {
     @Tag("remoteCDP")
     public void testFilterEmptyPublicData() throws Exception {
         try {
-            CogniteClient client = getCogniteClientAPIKey();
+            CogniteClient client = getCogniteClientOpenIndustrialData();
 
             Iterator<List<ThreeDNode>> itFilter = client.threeD()
                     .models()

--- a/src/test/java/com/cognite/client/TimeseriesIntegrationTest.java
+++ b/src/test/java/com/cognite/client/TimeseriesIntegrationTest.java
@@ -34,12 +34,7 @@ class TimeseriesIntegrationTest {
                 .withNoListPartitions(1);
         String loggingPrefix = "UnitTest - writeReadAndDeleteTimeseries() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
-        CogniteClient client = CogniteClient.ofClientCredentials(
-                    TestConfigProvider.getProject(),
-                    TestConfigProvider.getClientId(),
-                    TestConfigProvider.getClientSecret(),
-                    TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withBaseUrl(TestConfigProvider.getHost())
+        CogniteClient client = TestConfigProvider.getCogniteClient()
                 //.withClientConfig(config)
                 ;
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",
@@ -91,12 +86,7 @@ class TimeseriesIntegrationTest {
         String loggingPrefix = "UnitTest - writeReadAndDeleteTimeseriesDataPoints() -";
         LOG.info(loggingPrefix + "----------------------------------------------------------------------");
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
-        CogniteClient client = CogniteClient.ofClientCredentials(
-                    TestConfigProvider.getProject(),
-                    TestConfigProvider.getClientId(),
-                    TestConfigProvider.getClientSecret(),
-                    TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withBaseUrl(TestConfigProvider.getHost())
+        CogniteClient client = TestConfigProvider.getCogniteClient()
                 //.withClientConfig(config)
                 ;
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",
@@ -170,12 +160,7 @@ class TimeseriesIntegrationTest {
         Instant startInstant = Instant.now();
         String loggingPrefix = "UnitTest - writeEditAndDeleteTimeseries() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
-        CogniteClient client = CogniteClient.ofClientCredentials(
-                    TestConfigProvider.getProject(),
-                    TestConfigProvider.getClientId(),
-                    TestConfigProvider.getClientSecret(),
-                    TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withBaseUrl(TestConfigProvider.getHost())
+        CogniteClient client = TestConfigProvider.getCogniteClient()
                 ;
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",
                 Duration.between(startInstant, Instant.now()));
@@ -272,12 +257,7 @@ class TimeseriesIntegrationTest {
         Instant startInstant = Instant.now();
         String loggingPrefix = "UnitTest - writeReadAndDeleteTimeseries() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
-        CogniteClient client = CogniteClient.ofClientCredentials(
-                    TestConfigProvider.getProject(),
-                    TestConfigProvider.getClientId(),
-                    TestConfigProvider.getClientSecret(),
-                    TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withBaseUrl(TestConfigProvider.getHost())
+        CogniteClient client = TestConfigProvider.getCogniteClient()
                 //.withClientConfig(config)
                 ;
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",
@@ -337,12 +317,7 @@ class TimeseriesIntegrationTest {
 
         String loggingPrefix = "UnitTest - writeAggregateAndDeleteTimeseries() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
-        CogniteClient client = CogniteClient.ofClientCredentials(
-                    TestConfigProvider.getProject(),
-                    TestConfigProvider.getClientId(),
-                    TestConfigProvider.getClientSecret(),
-                    TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withBaseUrl(TestConfigProvider.getHost())
+        CogniteClient client = TestConfigProvider.getCogniteClient()
                 ;
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",
                 Duration.between(startInstant, Instant.now()));
@@ -401,12 +376,7 @@ class TimeseriesIntegrationTest {
         String loggingPrefix = "UnitTest - writeUploadQueueAndDeleteTimeseriesDataPoints() -";
         LOG.info(loggingPrefix + "----------------------------------------------------------------------");
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
-        CogniteClient client = CogniteClient.ofClientCredentials(
-                        TestConfigProvider.getClientId(),
-                        TestConfigProvider.getClientSecret(),
-                        TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                .withProject(TestConfigProvider.getProject())
-                .withBaseUrl(TestConfigProvider.getHost())
+        CogniteClient client = TestConfigProvider.getCogniteClient()
                 //.withClientConfig(config)
                 ;
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",

--- a/src/test/java/com/cognite/client/TimeseriesIntegrationTest.java
+++ b/src/test/java/com/cognite/client/TimeseriesIntegrationTest.java
@@ -35,10 +35,10 @@ class TimeseriesIntegrationTest {
         String loggingPrefix = "UnitTest - writeReadAndDeleteTimeseries() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
         CogniteClient client = CogniteClient.ofClientCredentials(
+                    TestConfigProvider.getProject(),
                     TestConfigProvider.getClientId(),
                     TestConfigProvider.getClientSecret(),
                     TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withProject(TestConfigProvider.getProject())
                     .withBaseUrl(TestConfigProvider.getHost())
                 //.withClientConfig(config)
                 ;
@@ -92,10 +92,10 @@ class TimeseriesIntegrationTest {
         LOG.info(loggingPrefix + "----------------------------------------------------------------------");
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
         CogniteClient client = CogniteClient.ofClientCredentials(
+                    TestConfigProvider.getProject(),
                     TestConfigProvider.getClientId(),
                     TestConfigProvider.getClientSecret(),
                     TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withProject(TestConfigProvider.getProject())
                     .withBaseUrl(TestConfigProvider.getHost())
                 //.withClientConfig(config)
                 ;
@@ -171,10 +171,10 @@ class TimeseriesIntegrationTest {
         String loggingPrefix = "UnitTest - writeEditAndDeleteTimeseries() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
         CogniteClient client = CogniteClient.ofClientCredentials(
+                    TestConfigProvider.getProject(),
                     TestConfigProvider.getClientId(),
                     TestConfigProvider.getClientSecret(),
                     TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withProject(TestConfigProvider.getProject())
                     .withBaseUrl(TestConfigProvider.getHost())
                 ;
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",
@@ -273,10 +273,10 @@ class TimeseriesIntegrationTest {
         String loggingPrefix = "UnitTest - writeReadAndDeleteTimeseries() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
         CogniteClient client = CogniteClient.ofClientCredentials(
+                    TestConfigProvider.getProject(),
                     TestConfigProvider.getClientId(),
                     TestConfigProvider.getClientSecret(),
                     TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withProject(TestConfigProvider.getProject())
                     .withBaseUrl(TestConfigProvider.getHost())
                 //.withClientConfig(config)
                 ;
@@ -338,10 +338,10 @@ class TimeseriesIntegrationTest {
         String loggingPrefix = "UnitTest - writeAggregateAndDeleteTimeseries() -";
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
         CogniteClient client = CogniteClient.ofClientCredentials(
+                    TestConfigProvider.getProject(),
                     TestConfigProvider.getClientId(),
                     TestConfigProvider.getClientSecret(),
                     TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                    .withProject(TestConfigProvider.getProject())
                     .withBaseUrl(TestConfigProvider.getHost())
                 ;
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",

--- a/src/test/java/com/cognite/client/TransformationJobsIntegrationTest.java
+++ b/src/test/java/com/cognite/client/TransformationJobsIntegrationTest.java
@@ -360,12 +360,7 @@ public class TransformationJobsIntegrationTest {
     }
 
     private CogniteClient getCogniteClient(Instant startInstant, String loggingPrefix) throws MalformedURLException {
-        CogniteClient client = CogniteClient.ofClientCredentials(
-                        TestConfigProvider.getClientId(),
-                        TestConfigProvider.getClientSecret(),
-                        TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                .withProject(TestConfigProvider.getProject())
-                .withBaseUrl(TestConfigProvider.getHost());
+        CogniteClient client = TestConfigProvider.getCogniteClient();
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",
                 Duration.between(startInstant, Instant.now()));
         return client;

--- a/src/test/java/com/cognite/client/TransformationNotificationsIntegrationTest.java
+++ b/src/test/java/com/cognite/client/TransformationNotificationsIntegrationTest.java
@@ -118,12 +118,7 @@ public class TransformationNotificationsIntegrationTest {
     }
 
     private CogniteClient getCogniteClient(Instant startInstant, String loggingPrefix) throws MalformedURLException {
-        CogniteClient client = CogniteClient.ofClientCredentials(
-                        TestConfigProvider.getClientId(),
-                        TestConfigProvider.getClientSecret(),
-                        TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                .withProject(TestConfigProvider.getProject())
-                .withBaseUrl(TestConfigProvider.getHost());
+        CogniteClient client = TestConfigProvider.getCogniteClient();
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",
                 Duration.between(startInstant, Instant.now()));
         return client;

--- a/src/test/java/com/cognite/client/TransformationSchedulesIntegrationTest.java
+++ b/src/test/java/com/cognite/client/TransformationSchedulesIntegrationTest.java
@@ -273,12 +273,7 @@ public class TransformationSchedulesIntegrationTest {
     }
 
     private CogniteClient getCogniteClient(Instant startInstant, String loggingPrefix) throws MalformedURLException {
-        CogniteClient client = CogniteClient.ofClientCredentials(
-                        TestConfigProvider.getClientId(),
-                        TestConfigProvider.getClientSecret(),
-                        TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                .withProject(TestConfigProvider.getProject())
-                .withBaseUrl(TestConfigProvider.getHost());
+        CogniteClient client = TestConfigProvider.getCogniteClient();
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",
                 Duration.between(startInstant, Instant.now()));
         return client;

--- a/src/test/java/com/cognite/client/TransformationsIntegrationTest.java
+++ b/src/test/java/com/cognite/client/TransformationsIntegrationTest.java
@@ -232,12 +232,7 @@ public class TransformationsIntegrationTest {
     }
 
     private CogniteClient getCogniteClient(Instant startInstant, String loggingPrefix) throws MalformedURLException {
-        CogniteClient client = CogniteClient.ofClientCredentials(
-                        TestConfigProvider.getClientId(),
-                        TestConfigProvider.getClientSecret(),
-                        TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                .withProject(TestConfigProvider.getProject())
-                .withBaseUrl(TestConfigProvider.getHost());
+        CogniteClient client = TestConfigProvider.getCogniteClient();
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",
                 Duration.between(startInstant, Instant.now()));
         return client;

--- a/src/test/java/com/cognite/client/statestore/LocalStateStoreIntegrationTest.java
+++ b/src/test/java/com/cognite/client/statestore/LocalStateStoreIntegrationTest.java
@@ -32,12 +32,7 @@ class LocalStateStoreIntegrationTest {
         String loggingPrefix = "UnitTest - createCommitAndLoadStates() -";
         LOG.info(loggingPrefix + "----------------------------------------------------------------------");
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
-        CogniteClient client = CogniteClient.ofClientCredentials(
-                        TestConfigProvider.getClientId(),
-                        TestConfigProvider.getClientSecret(),
-                        TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                .withProject(TestConfigProvider.getProject())
-                .withBaseUrl(TestConfigProvider.getHost())
+        CogniteClient client = TestConfigProvider.getCogniteClient()
                 //.withClientConfig(config)
                 ;
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",

--- a/src/test/java/com/cognite/client/statestore/RawStateStoreIntegrationTest.java
+++ b/src/test/java/com/cognite/client/statestore/RawStateStoreIntegrationTest.java
@@ -31,12 +31,7 @@ class RawStateStoreIntegrationTest {
         String loggingPrefix = "UnitTest - createCommitAndLoadStates() -";
         LOG.info(loggingPrefix + "----------------------------------------------------------------------");
         LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
-        CogniteClient client = CogniteClient.ofClientCredentials(
-                        TestConfigProvider.getClientId(),
-                        TestConfigProvider.getClientSecret(),
-                        TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                .withProject(TestConfigProvider.getProject())
-                .withBaseUrl(TestConfigProvider.getHost())
+        CogniteClient client = TestConfigProvider.getCogniteClient()
                 //.withClientConfig(config)
                 ;
         LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",


### PR DESCRIPTION
Harden the SDK to ensure that a CDF project is always specified. 

Main change #1:
- Add new CogniteClient factory methods which includes cdfProject as a parameter.
- Deprecate (but not remove) existing CogniteClient factory methods without the cdfProject parameter
Background for this change is to move towards making cdfProject a mandatory attribute at CogniteClient instantiation time. 

Main change #2:
- Add test to check that the cdfProject is specified when the SDK builds the internal auth state. If cdfProject is not specified, the SDK will fail fast with a relevant error message. 
The exception to the test above is if the SDK runs with API key. In this case we can infer the cdfProject (legacy logic). 

Main change #3:
- Refactor all tests to use the new CogniteClient factory methods.