### PR TITLE
Support trailing slash in base URL.

### DIFF
--- a/src/main/java/com/cognite/client/CogniteClient.java
+++ b/src/main/java/com/cognite/client/CogniteClient.java
@@ -182,7 +182,8 @@ public abstract class CogniteClient implements Serializable {
                                                     String clientSecret,
                                                     URL tokenUrl) {
        return CogniteClient.ofClientCredentials(
-               cdfProject, clientId, clientSecret, tokenUrl, List.of(DEFAULT_BASE_URL + "/.default"));
+               cdfProject, clientId, clientSecret, tokenUrl,
+               List.of(createScope(DEFAULT_BASE_URL)));
     }
 
     protected abstract Builder toBuilder();
@@ -223,8 +224,8 @@ public abstract class CogniteClient implements Serializable {
     /**
      * Returns a {@link CogniteClient} using the specified base URL for issuing API requests.
      *
-     * The base URL must follow the format {@code https://<my-host>.cognitedata.com}. The default
-     * base URL is {@code https://api.cognitedata.com}
+     * The base URL must follow the format {@code https://<my-host>.cognitedata.com}, with an
+     * optional trailing slash. The default base URL is {@code https://api.cognitedata.com}
      *
      * @param baseUrl The CDF api base URL
      * @return the client object with the base URL set.
@@ -254,8 +255,8 @@ public abstract class CogniteClient implements Serializable {
                 interceptors.add(new TokenInterceptor(host, getTokenSupplier()));
                 break;
             case CLIENT_CREDENTIALS:
-                String currentDefaultScope = getBaseUrl() + "/.default";
-                String newDefaultScope = baseUrl + "/.default";
+                String currentDefaultScope = createScope(getBaseUrl());
+                String newDefaultScope = createScope(baseUrl);
                 Collection<String> scopes = List.of(newDefaultScope); // Fallback scopes
                 if (null != getAuthScopes()) {
                     // Iterate the current scopes. If any of them match the "default scope", replace with
@@ -547,6 +548,11 @@ public abstract class CogniteClient implements Serializable {
     protected AuthConfig buildAuthConfig() throws Exception {
         return AuthConfig.of(getProject())
                 .withHost(getBaseUrl());
+    }
+
+    private static String createScope(String baseUrl) {
+        final String separator = baseUrl.endsWith("/") ? "" : "/";
+        return baseUrl + separator + ".default";
     }
 
     /*

--- a/src/test/java/com/cognite/client/CogniteClientUnitTest.java
+++ b/src/test/java/com/cognite/client/CogniteClientUnitTest.java
@@ -20,8 +20,22 @@ class CogniteClientUnitTest {
         assertEquals(1, interceptorList.size());
         assertEquals("com.cognite.client.CogniteClient$ClientCredentialsInterceptor", interceptorList.get(0).getClass().getName());
         assertEquals("https://localhost", client.getBaseUrl());
+        assertEquals(List.of("https://localhost/.default"), client.getAuthScopes());
     }
 
+    @Test
+    void test_ofClientCredentials_config_with_trailing_slash_in_baseUrl() throws Exception {
+        CogniteClient client = CogniteClient.ofClientCredentials("myCdfProject", "123", "secret", new URL("https://localhost/cogniteapi"))
+            .withBaseUrl("https://localhost/");
+        assertNotNull(client.getHttpClient());
+        List<Interceptor> interceptorList = client.getHttpClient().interceptors();
+        assertDoesNotThrow(() -> client.buildAuthConfig());
+        assertNotNull(interceptorList);
+        assertEquals(1, interceptorList.size());
+        assertEquals("com.cognite.client.CogniteClient$ClientCredentialsInterceptor", interceptorList.get(0).getClass().getName());
+        assertEquals("https://localhost/", client.getBaseUrl());
+        assertEquals(List.of("https://localhost/.default"), client.getAuthScopes());
+    }
 
     @Test
     void test_withHttp_config() throws Exception {
@@ -37,5 +51,4 @@ class CogniteClientUnitTest {
         List<ConnectionSpec> connectionSpecs = client.getHttpClient().connectionSpecs();
         assertEquals(3, connectionSpecs.size());
     }
-
 }

--- a/src/test/java/com/cognite/client/TestConfigProvider.java
+++ b/src/test/java/com/cognite/client/TestConfigProvider.java
@@ -10,12 +10,16 @@ import java.net.MalformedURLException;
  */
 public class TestConfigProvider {
     public static CogniteClient getCogniteClient() throws MalformedURLException {
+        return getCogniteClient(false);
+    }
+
+    public static CogniteClient getCogniteClient(boolean addTrailingSlashToBaseUrl) throws MalformedURLException {
         return CogniteClient.ofClientCredentials(
                         TestConfigProvider.getProject(),
                         TestConfigProvider.getClientId(),
                         TestConfigProvider.getClientSecret(),
                         TokenUrl.generateAzureAdURL(TestConfigProvider.getTenantId()))
-                .withBaseUrl(TestConfigProvider.getHost());
+                .withBaseUrl(TestConfigProvider.getHost() + (addTrailingSlashToBaseUrl ? "/" : ""));
     }
 
     public static CogniteClient getOpenIndustrialDataCogniteClient() throws MalformedURLException {

--- a/src/test/java/com/cognite/client/TimeseriesIntegrationTest.java
+++ b/src/test/java/com/cognite/client/TimeseriesIntegrationTest.java
@@ -454,4 +454,25 @@ class TimeseriesIntegrationTest {
         assertEquals(upsertTimeseriesList.size(), listTimeseriesResults.size());
         assertEquals(deleteItemsInput.size(), deleteItemsResults.size());
     }
+
+    // This test is for the client in general, but we had to pick some resource type to test it with
+    @Test
+    @Tag("remoteCDP")
+    void trailingSlashInBaseUrl() throws Exception {
+        Instant startInstant = Instant.now();
+        String loggingPrefix = "UnitTest - trailingSlashInBaseUrl() -";
+        LOG.info(loggingPrefix + "Start test. Creating Cognite client.");
+        CogniteClient client = TestConfigProvider.getCogniteClient(true);
+        LOG.info(loggingPrefix + "Finished creating the Cognite client. Duration : {}",
+            Duration.between(startInstant, Instant.now()));
+
+        // We don't expect to get any timeseries here; the API call just needs to not fail
+        LOG.info(loggingPrefix + "Start listing timeseries.");
+        client.timeseries()
+            .list(Request.create()
+                .withFilterMetadataParameter("source", DataGenerator.sourceValue))
+            .forEachRemaining(timeseries -> {});
+        LOG.info(loggingPrefix + "Finished listing timeseries. Duration: {}",
+            Duration.between(startInstant, Instant.now()));
+    }
 }


### PR DESCRIPTION
While there is technically a difference between a URL that ends in a slash and one that does not, it is so common to supply a trailing slash in base URLs that this is a substantial trap, which is hard to debug because the resulting authentication error is quite opaque (I just wasted two hours because of this). Furthermore, the Python SDK already accepts a trailing slash.