### PR TITLE
Don't retry when response status code is 404.

### DIFF
--- a/src/main/java/com/cognite/client/RawRows.java
+++ b/src/main/java/com/cognite/client/RawRows.java
@@ -25,6 +25,7 @@ import com.cognite.client.servicesV1.ConnectorConstants;
 import com.cognite.client.servicesV1.ConnectorServiceV1;
 import com.cognite.client.servicesV1.ItemReader;
 import com.cognite.client.servicesV1.ResponseItems;
+import com.cognite.client.servicesV1.exception.CdfRawNotFoundException;
 import com.cognite.client.servicesV1.parser.RawParser;
 import com.cognite.client.stream.RawPublisher;
 import com.google.auto.value.AutoValue;
@@ -425,7 +426,11 @@ public abstract class RawRows extends ApiBase implements UpsertTarget<RawRow, Ra
                 completedBatches.addAll(response.getResultsItems());
                 LOG.debug(loggingPrefix + "Retrieve row request success. Adding row to result collection.");
             } else {
-                LOG.error(loggingPrefix + "Retrieve row request failed: {}", response.getResponseBodyAsString());
+                if (!response.getStatus().isEmpty() && response.getStatus().get(0) == "404") {
+                    LOG.error(loggingPrefix + "Retrieve row request failed: {}", response.getResponseBodyAsString());
+                    throw new CdfRawNotFoundException(String.format(loggingPrefix + "Retrieve row request failed: %s",
+                            response.getResponseBodyAsString()));
+                }
                 throw new Exception(String.format(loggingPrefix + "Retrieve row request failed: %s",
                         response.getResponseBodyAsString()));
             }

--- a/src/main/java/com/cognite/client/servicesV1/ConnectorServiceV1.java
+++ b/src/main/java/com/cognite/client/servicesV1/ConnectorServiceV1.java
@@ -2498,7 +2498,7 @@ public abstract class ConnectorServiceV1 implements Serializable {
                     .setRequestExecutor(RequestExecutor.of(client.getHttpClient())
                             .withExecutor(client.getExecutorService())
                             .withMaxRetries(client.getClientConfig().getMaxRetries())
-                            .withValidResponseCodes(ImmutableList.of(400, 401, 409, 422)))
+                            .withValidResponseCodes(ImmutableList.of(400, 401, 404, 409, 422)))
                     .setRequestProvider(requestProvider)
                     .setResponseParser(responseParser)
                     .build();

--- a/src/main/java/com/cognite/client/servicesV1/exception/CdfRawNotFoundException.java
+++ b/src/main/java/com/cognite/client/servicesV1/exception/CdfRawNotFoundException.java
@@ -1,0 +1,11 @@
+package com.cognite.client.servicesV1.exception;
+
+/**
+ * Signals that CDF RAW did not find row with a specific key.
+ */
+public class CdfRawNotFoundException extends Exception {
+    public CdfRawNotFoundException(String errorMessage) {
+        super(errorMessage);
+    }
+}
+


### PR DESCRIPTION
Currently when we get a 404 from RAW we retry the request. This is wrong behaviour as when we get a 404 from RAW it means the key/row does not exist, and thus we should not retry.

When returned status code is 404 it means the key does not exist. Don't retry when that is the case.

I don't know who to send this PR too as the main maintainer is not in Cognite anymore.