### PR TITLE
transformations: add support for data model destination type

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ SDK v2
 <dependency>    
     <groupId>com.cognite</groupId>
     <artifactId>cdf-sdk-java</artifactId>
-    <version>2.2.1</version>
+    <version>2.3.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.cognite</groupId>
     <artifactId>cdf-sdk-java</artifactId>
-    <version>2.2.1</version>
+    <version>2.3.0</version>
     <licenses>
         <license>
             <name>Apache 2</name>

--- a/releases.md
+++ b/releases.md
@@ -19,6 +19,12 @@ Changes are grouped as follows:
 - Extraction pipelines configuration
 - Data models
 
+## [2.3.0] 2024-02-13
+
+### Added
+
+- Added support for returning data model destination type when retrieving transformation jobs.
+
 ## [2.2.1] 2023-11-16
 
 ### Added

--- a/src/main/java/com/cognite/client/servicesV1/parser/TransformationJobsParser.java
+++ b/src/main/java/com/cognite/client/servicesV1/parser/TransformationJobsParser.java
@@ -74,6 +74,35 @@ public class TransformationJobsParser {
                         builderDest.setExternalId(sequenceRowDataSourceNode.path("externalId").textValue());
                     }
                     tmBuilder.setDestination(builderDest.build());
+                } else if (root.path("destination").path("type").textValue().equals("instances")) {
+                    JsonNode instanceDataSourceNode = root.path("destination");
+                    Transformation.Destination.Builder builderDest = Transformation.Destination.newBuilder();
+
+                    builderDest.setType(instanceDataSourceNode.path("type").textValue());
+
+                    if (instanceDataSourceNode.path("dataModel").isObject()) {
+                        JsonNode dataModelSourceNode = instanceDataSourceNode.path("dataModel");
+                        Transformation.Destination.Datamodel.Builder dataModelBuilderDest = Transformation.Destination.Datamodel.newBuilder();
+                        JsonNode space = dataModelSourceNode.path("space");
+                        JsonNode externalId = dataModelSourceNode.path("externalId");
+                        JsonNode version = dataModelSourceNode.path("version");
+                        JsonNode destinationType = dataModelSourceNode.path("destinationType");
+                        if (space.isTextual())
+                            dataModelBuilderDest.setSpace(space.textValue());
+                        if (externalId.isTextual())
+                            dataModelBuilderDest.setExternalId(externalId.textValue());
+                        if (version.isTextual())
+                            dataModelBuilderDest.setVersion(version.textValue());
+                        if (destinationType.isTextual())
+                            dataModelBuilderDest.setDestinationType(destinationType.textValue());
+
+                        builderDest.setDataModel(dataModelBuilderDest.build());
+                    }
+                    JsonNode instanceSpace = instanceDataSourceNode.path("instanceSpace");
+                    if (instanceSpace.isTextual())
+                        builderDest.setInstanceSpace(instanceSpace.textValue());
+
+                    tmBuilder.setDestination(builderDest.build());
                 }
             }
         }

--- a/src/main/proto/transformation.proto
+++ b/src/main/proto/transformation.proto
@@ -11,6 +11,14 @@ message Transformation {
 
   message Destination {
 
+    message Datamodel {
+      string space = 1;
+      string external_id = 2;
+      string version = 3;
+      string destination_type = 4;
+      string destination_relationship_from_type = 5;
+    }
+
     enum DataSourceType {
       ASSETS = 0;
       TIMESERIES = 1;
@@ -24,12 +32,15 @@ message Transformation {
       LABELS = 9;
       RELATIONSHIPS = 10;
       DATA_SETS = 11;
+      INSTANCES = 12;
     }
 
     optional string type = 2;
     optional string database = 3;
     optional string table = 4;
     string external_id = 5;
+    optional Datamodel data_model = 6;
+    optional string instance_space = 7;
   }
 
   message FlatOidcCredentials {


### PR DESCRIPTION
Adds support for handling the data model destination. We need this in our project in order to see which type the transformation is writing to. I've tested this with both a RAW transformation and a data model transformation.

Old transformation:
```
id: 25564067
uuid: "dfb67644-2b78-4a7a-8c13-77301ab9e1f5"
transformation_id: 20212
transformation_external_id: "tr-lci:UnitOfMeasure"
source_project: "akerbp-dev"
destination_project: "akerbp-dev"
conflict_mode: "tl:dr"
created_time: 1707837423707
started_time: 1707837425152
finished_time: 1707837426349
last_seen_time: 1707837425782
status: "Completed"
```

new (RAW):
```
id: 25564075
uuid: "0de68168-44cd-4002-b08a-a6bb14cdacc7"
transformation_id: 22889
transformation_external_id: "tr-lci_export:pbi_Property"
source_project: "akerbp-dev"
destination_project: "akerbp-dev"
destination {
  type: "raw"
  database: "lci-export"
  table: "Property"
}
conflict_mode: "tl:dr"
created_time: 1707837564960
started_time: 1707837566617
finished_time: 1707837569966
status: "Completed"
```

new (data model):
```
id: 25564071
uuid: "84f000b8-019a-4151-8fac-68340b575ea1"
transformation_id: 20212
transformation_external_id: "tr-lci:UnitOfMeasure"
source_project: "akerbp-dev"
destination_project: "akerbp-dev"
destination {
  type: "instances"
  data_model {
    space: "yggdrasil-twin"
    external_id: "yggdrasil_twin"
    version: "12"
    destination_type: "UnitOfMeasure"
  }
  instance_space: "yggdrasil-twin"
}
conflict_mode: "tl:dr"
created_time: 1707837482015
started_time: 1707837483330
finished_time: 1707837484371
status: "Completed"
```