### PR TITLE
Bump dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.cognite</groupId>
     <artifactId>cdf-sdk-java</artifactId>
-    <version>2.3.0</version>
+    <version>2.3.1</version>
     <licenses>
         <license>
             <name>Apache 2</name>


### PR DESCRIPTION
There have been reported issues about CVE vulnerabilities related to grpc. Although these vulnerabilities do not affect the java grpc library it's probably nice to bump related dependencies as a precaution.

Only bumping the version as the changes are already merged through `renovate` and `dependabot`