### PR TITLE
CDF-21924 pom.xml: Explicitly exclude com.lowagie:itext

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,18 @@
             <groupId>com.nimbusds</groupId>
             <artifactId>oauth2-oidc-sdk</artifactId>
             <version>${nimbusds.version}</version>
+            <!--
+                https://cognitedata.atlassian.net/browse/CDFBUG-654
+                com.lowagie:itext has IP rights issues. It is a dependency
+                of a dependency of an optional dependency and should not
+                normally be pulled in, but just to be clear: Exclude.
+            -->
+            <exclusions>
+                <exclusion>
+                    <groupId>com.lowagie</groupId>
+                    <artifactId>itext</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.google.cloud</groupId>


### PR DESCRIPTION
The maven package com.lowagie:itext:2.1.7, which is a dependency of an old spring boot test version which is a test dependency of opensaml which is an optional dependency of oauth2-oidc-sdk, may contain unlicensed copyrighted code. We do not have a dependency on it, and it should not be pulled in as it's an optional dependency, but just to be explicit about it we can add an exclude.