### PR TITLE
Added support to add the unit external id to TimeseriesMetadata

### DIFF
--- a/docs/timeSeries.md
+++ b/docs/timeSeries.md
@@ -31,7 +31,8 @@ List<TimeseriesMetadata> upsertTimeseriesList = List.of(TimeseriesMetadata.newBu
    .setIsString(false) 
    .setIsStep(false) 
    .setDescription("Description") 
-   .setUnit("TestUnits") 
+   .setUnit("TestUnits")
+   .setUnitExternalId("testUnitExternalId")     
    .putMetadata("type", "sdk-data-generator") 
    .putMetadata("sdk-data-generator", "sdk-data-generator") 
  .build()); 

--- a/docs/timeSeries.md
+++ b/docs/timeSeries.md
@@ -32,7 +32,7 @@ List<TimeseriesMetadata> upsertTimeseriesList = List.of(TimeseriesMetadata.newBu
    .setIsStep(false) 
    .setDescription("Description") 
    .setUnit("TestUnits")
-   .setUnitExternalId("testUnitExternalId")     
+   .setUnitExternalId("TestUnitExternalId")     
    .putMetadata("type", "sdk-data-generator") 
    .putMetadata("sdk-data-generator", "sdk-data-generator") 
  .build()); 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.cognite</groupId>
     <artifactId>cdf-sdk-java</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <licenses>
         <license>
             <name>Apache 2</name>

--- a/src/main/java/com/cognite/client/servicesV1/parser/TimeseriesParser.java
+++ b/src/main/java/com/cognite/client/servicesV1/parser/TimeseriesParser.java
@@ -303,6 +303,10 @@ public class TimeseriesParser {
             }
         }
 
+        if (root.path("unitExternalId").isTextual()) {
+            builder.setUnitExternalId(root.get("unitExternalId").textValue());
+        }
+
         return builder.build();
     }
 
@@ -352,6 +356,10 @@ public class TimeseriesParser {
             mapBuilder.put("dataSetId", element.getDataSetId());
         }
 
+        if (element.hasUnitExternalId()) {
+            mapBuilder.put("unitExternalId", element.getUnitExternalId());
+        }
+
         return mapBuilder.build();
     }
 
@@ -398,6 +406,9 @@ public class TimeseriesParser {
         }
         if (element.hasDataSetId()) {
             updateNodeBuilder.put("dataSetId", ImmutableMap.of("set", element.getDataSetId()));
+        }
+        if (element.hasUnitExternalId()) {
+            updateNodeBuilder.put("unitExternalId", ImmutableMap.of("set", element.getUnitExternalId()));
         }
         mapBuilder.put("update", updateNodeBuilder.build());
         return mapBuilder.build();
@@ -464,6 +475,12 @@ public class TimeseriesParser {
             updateNodeBuilder.put("dataSetId", ImmutableMap.of("set", element.getDataSetId()));
         } else {
             updateNodeBuilder.put("dataSetId", ImmutableMap.of("setNull", true));
+        }
+
+        if (element.hasUnitExternalId()) {
+            updateNodeBuilder.put("unitExternalId", ImmutableMap.of("set", element.getUnitExternalId()));
+        } else {
+            updateNodeBuilder.put("unitExternalId", ImmutableMap.of("setNull", true));
         }
 
         mapBuilder.put("update", updateNodeBuilder.build());

--- a/src/main/proto/timeseries.proto
+++ b/src/main/proto/timeseries.proto
@@ -22,6 +22,7 @@ message TimeseriesMetadata {
     optional int64 last_updated_time = 11;
     map<string, string> metadata = 12;
     optional int64 data_set_id = 13;
+    optional string unit_external_id = 14;
 }
 
 /*


### PR DESCRIPTION
We wanted to add the unitExternalId to the TimeseriesMetadata as it was available in the create timeseries API.
As there is no provision to set the unitExternalId, we have made the necessary changes in the code.