### PR TITLE
Added provision to reset the unit and unitExternalId field of TimeseriesMetadata

### DIFF
--- a/docs/timeSeries.md
+++ b/docs/timeSeries.md
@@ -31,7 +31,8 @@ List<TimeseriesMetadata> upsertTimeseriesList = List.of(TimeseriesMetadata.newBu
    .setIsString(false) 
    .setIsStep(false) 
    .setDescription("Description") 
-   .setUnit("TestUnits") 
+   .setUnit("TestUnits")
+   .setUnitExternalId("testUnitExternalId")
    .putMetadata("type", "sdk-data-generator") 
    .putMetadata("sdk-data-generator", "sdk-data-generator") 
  .build()); 

--- a/docs/timeSeries.md
+++ b/docs/timeSeries.md
@@ -40,8 +40,25 @@ List<TimeseriesMetadata> upsertTimeseriesList = List.of(TimeseriesMetadata.newBu
 client.timeseries().upsert(upsertTimeseriesList); 
 
 
-```
+``` 
+To reset the unit and unitExternalId field, set `unit` and `unitExternalId` field with empty string- 
 
+```java
+List<TimeseriesMetadata> upsertTimeseriesList = List.of(TimeseriesMetadata.newBuilder()
+.setExternalId("10")
+.setName("test_ts")
+.setIsString(false)
+.setIsStep(false)
+.setDescription("Description")
+.setUnit("")
+.setUnitExternalId("")
+.putMetadata("type", "sdk-data-generator")
+.putMetadata("sdk-data-generator", "sdk-data-generator")
+.build());
+
+client.timeseries().upsert(upsertTimeseriesList);
+```
+This will reset the both(unit & unitExternalId field)
 ### Retrieve time series
 
 Retrieve one or more time series by ID or external ID. The time series are returned in the same order as in the request.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.cognite</groupId>
     <artifactId>cdf-sdk-java</artifactId>
-    <version>2.3.1</version>
+    <version>2.3.2</version>
     <licenses>
         <license>
             <name>Apache 2</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.cognite</groupId>
     <artifactId>cdf-sdk-java</artifactId>
-    <version>2.3.2</version>
+    <version>2.3.3</version>
     <licenses>
         <license>
             <name>Apache 2</name>

--- a/src/main/java/com/cognite/client/servicesV1/parser/TimeseriesParser.java
+++ b/src/main/java/com/cognite/client/servicesV1/parser/TimeseriesParser.java
@@ -340,7 +340,7 @@ public class TimeseriesParser {
         if (element.hasDescription()) {
             mapBuilder.put("description", element.getDescription());
         }
-        if (element.hasUnit()) {
+        if (element.hasUnit() && !element.getUnit().trim().isEmpty()) {
             mapBuilder.put("unit", element.getUnit());
         }
         if (element.hasAssetId()) {
@@ -356,7 +356,7 @@ public class TimeseriesParser {
             mapBuilder.put("dataSetId", element.getDataSetId());
         }
 
-        if (element.hasUnitExternalId()) {
+        if (element.hasUnitExternalId() && !element.getUnitExternalId().trim().isEmpty()) {
             mapBuilder.put("unitExternalId", element.getUnitExternalId());
         }
 
@@ -392,9 +392,12 @@ public class TimeseriesParser {
         if (element.hasDescription()) {
             updateNodeBuilder.put("description", ImmutableMap.of("set", element.getDescription()));
         }
-        if (element.hasUnit()) {
+        if (element.hasUnit() && !element.getUnit().trim().isEmpty()) {
             updateNodeBuilder.put("unit", ImmutableMap.of("set", element.getUnit()));
+        } else {
+            updateNodeBuilder.put("unit", ImmutableMap.of("setNull", true));
         }
+
         if (element.hasAssetId()) {
             updateNodeBuilder.put("assetId", ImmutableMap.of("set", element.getAssetId()));
         }
@@ -408,7 +411,11 @@ public class TimeseriesParser {
             updateNodeBuilder.put("dataSetId", ImmutableMap.of("set", element.getDataSetId()));
         }
         if (element.hasUnitExternalId()) {
-            updateNodeBuilder.put("unitExternalId", ImmutableMap.of("set", element.getUnitExternalId()));
+            if (element.getUnitExternalId().trim().isEmpty()) {
+                updateNodeBuilder.put("unitExternalId", ImmutableMap.of("setNull", true));
+            } else {
+                updateNodeBuilder.put("unitExternalId", ImmutableMap.of("set", element.getUnitExternalId()));
+            }
         }
         mapBuilder.put("update", updateNodeBuilder.build());
         return mapBuilder.build();

--- a/src/main/java/com/cognite/client/servicesV1/parser/TimeseriesParser.java
+++ b/src/main/java/com/cognite/client/servicesV1/parser/TimeseriesParser.java
@@ -263,6 +263,10 @@ public class TimeseriesParser {
         if (root.path("externalId").isTextual()) {
             builder.setExternalId(root.get("externalId").textValue());
         }
+        if (root.path("unitExternalId").isTextual()) {
+            builder.setUnitExternalId(root.get("unitExternalId").textValue());
+        }
+
         if (root.path("name").isTextual()) {
             builder.setName(root.get("name").textValue());
         }
@@ -352,6 +356,10 @@ public class TimeseriesParser {
             mapBuilder.put("dataSetId", element.getDataSetId());
         }
 
+        if (element.hasUnitExternalId()) {
+            mapBuilder.put("unitExternalId", element.getUnitExternalId());
+        }
+
         return mapBuilder.build();
     }
 
@@ -398,6 +406,9 @@ public class TimeseriesParser {
         }
         if (element.hasDataSetId()) {
             updateNodeBuilder.put("dataSetId", ImmutableMap.of("set", element.getDataSetId()));
+        }
+        if (element.hasUnitExternalId()) {
+            updateNodeBuilder.put("unitExternalId", ImmutableMap.of("set", element.getUnitExternalId()));
         }
         mapBuilder.put("update", updateNodeBuilder.build());
         return mapBuilder.build();
@@ -465,6 +476,13 @@ public class TimeseriesParser {
         } else {
             updateNodeBuilder.put("dataSetId", ImmutableMap.of("setNull", true));
         }
+
+        if (element.hasUnitExternalId()) {
+            updateNodeBuilder.put("unitExternalId", ImmutableMap.of("set", element.getUnitExternalId()));
+        } else {
+            updateNodeBuilder.put("unitExternalId", ImmutableMap.of("setNull", true));
+        }
+
 
         mapBuilder.put("update", updateNodeBuilder.build());
         return mapBuilder.build();

--- a/src/main/proto/timeseries.proto
+++ b/src/main/proto/timeseries.proto
@@ -22,6 +22,7 @@ message TimeseriesMetadata {
     optional int64 last_updated_time = 11;
     map<string, string> metadata = 12;
     optional int64 data_set_id = 13;
+    optional string unit_external_id = 14;
 }
 
 /*


### PR DESCRIPTION
As a part of these changes while building the request, I have verified the value of the unit and unitExternalId field.
if it is an empty string or blank space we are setting it to setNull to true.

This is needed for one of the scenarios where TimeseriesMetadata object gets updated with the unit value as blank/some other value that is not present in the unit catalogue. We wanted to reset the unitExternalId field when unit value is blank hence added this change.