### PR TITLE
Add initial (low noise) gemini configuration

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,10 @@
+have_fun: false
+code_review:
+  disable: false
+  comment_severity_threshold: HIGH
+  max_review_comments: -1
+  pull_request_opened:
+    help: false
+    summary: false
+    code_review: false
+ignore_patterns: []


### PR DESCRIPTION
We are rolling out Gemini to all risk reviewed repositories, but before then we want to have a basic low-risk configuration rolled out